### PR TITLE
Make highlightjs theme configurable

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -14,6 +14,7 @@ port     = 3306
 site_name         = WriteFreely Example Blog!
 host              = http://localhost:8080
 theme             = write
+highlighter_theme = atom-one-light
 disable_js        = false
 webfonts          = true
 single_user       = true

--- a/config/config.go
+++ b/config/config.go
@@ -63,13 +63,14 @@ type (
 		Host     string `ini:"host"`
 
 		// Site appearance
-		Theme      string `ini:"theme"`
-		Editor     string `ini:"editor"`
-		JSDisabled bool   `ini:"disable_js"`
-		WebFonts   bool   `ini:"webfonts"`
-		Landing    string `ini:"landing"`
-		SimpleNav  bool   `ini:"simple_nav"`
-		WFModesty  bool   `ini:"wf_modesty"`
+		Theme            string `ini:"theme"`
+		HighlighterTheme string `ini:"highlighter_theme"`
+		Editor           string `ini:"editor"`
+		JSDisabled       bool   `ini:"disable_js"`
+		WebFonts         bool   `ini:"webfonts"`
+		Landing          string `ini:"landing"`
+		SimpleNav        bool   `ini:"simple_nav"`
+		WFModesty        bool   `ini:"wf_modesty"`
 
 		// Site functionality
 		Chorus        bool `ini:"chorus"`
@@ -112,14 +113,15 @@ func New() *Config {
 			Bind: "localhost", /* IPV6 support when not using localhost? */
 		},
 		App: AppCfg{
-			Host:           "http://localhost:8080",
-			Theme:          "write",
-			WebFonts:       true,
-			SingleUser:     true,
-			MinUsernameLen: 3,
-			MaxBlogs:       1,
-			Federation:     true,
-			PublicStats:    true,
+			Host:             "http://localhost:8080",
+			Theme:            "write",
+			HighlighterTheme: "atom-one-light",
+			WebFonts:         true,
+			SingleUser:       true,
+			MinUsernameLen:   3,
+			MaxBlogs:         1,
+			Federation:       true,
+			PublicStats:      true,
 		},
 	}
 	c.UseMySQL(true)

--- a/templates/include/post-render.tmpl
+++ b/templates/include/post-render.tmpl
@@ -52,7 +52,7 @@
       // We have blocks to be highlighted, so we load css
       var st = document.createElement('link');
       st.rel = "stylesheet";
-      st.href = "/css/lib/atom-one-light.min.css";
+      st.href = "/css/lib/{{.HighlighterTheme}}.min.css";
       document.head.appendChild(st);
 
       // Construct set of files to load, in order


### PR DESCRIPTION
Building on top of #31 this adds an option to the config.ini that allows to set a global theme.

*pros*
 * Allows instances to change the highlightjs theme to their wishes.
 * Works fine for single user instances.

*cons*
 * Admins need to download the themes first. Maybe use a CDN URL instead of a local one?
 * Setting is global for all users.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
