### PR TITLE
Accept general text/* files on post import

### DIFF
--- a/templates/user/import.tmpl
+++ b/templates/user/import.tmpl
@@ -29,7 +29,7 @@
 	<div class="formContainer">
 		<form id="importPosts" class="prominent" enctype="multipart/form-data" action="/api/me/import" method="POST">
 			<label>Select some files to import:
-				<input id="fileInput" class="fileInput" name="files" type="file" multiple accept="text/markdown, text/plain"/>
+				<input id="fileInput" class="fileInput" name="files" type="file" multiple accept="text/*"/>
 			</label>
 			<input id="fileDates" name="fileDates" hidden/>
 			<label>


### PR DESCRIPTION
This fixes an issue with Safari not allowing users to select *.md files.

Closes #334

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
