### PR TITLE
Update repo URL to writefreely org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! We're glad you're interested in contributing to WriteFreely.
 
 For **questions**, **help**, **feature requests**, and **general discussion**, please use [our forum](https://discuss.write.as).
 
-For **bug reports**, please [open a GitHub issue](https://github.com/writeas/writefreely/issues/new). See our guide on [submitting bug reports](https://writefreely.org/contribute#bugs).
+For **bug reports**, please [open a GitHub issue](https://github.com/writefreely/writefreely/issues/new). See our guide on [submitting bug reports](https://writefreely.org/contribute#bugs).
 
 ## Getting Started
 
@@ -80,9 +80,9 @@ We highly value commit messages that follow established form within the project.
 
 When in doubt, look to our existing git history for examples of good commit messages. Here are a few:
 
-* [Rename Suspend status to Silence](https://github.com/writeas/writefreely/commit/7e014ca65958750ab703e317b1ce8cfc4aad2d6e)
-* [Show 404 when remote user not found](https://github.com/writeas/writefreely/commit/867eb53b3596bd7b3f2be3c53a3faf857f4cd36d)
-* [Fix post deletion on Pleroma](https://github.com/writeas/writefreely/commit/fe82cbb96e3d5c57cfde0db76c28c4ea6dabfe50)
+* [Rename Suspend status to Silence](https://github.com/writefreely/writefreely/commit/7e014ca65958750ab703e317b1ce8cfc4aad2d6e)
+* [Show 404 when remote user not found](https://github.com/writefreely/writefreely/commit/867eb53b3596bd7b3f2be3c53a3faf857f4cd36d)
+* [Fix post deletion on Pleroma](https://github.com/writefreely/writefreely/commit/fe82cbb96e3d5c57cfde0db76c28c4ea6dabfe50)
 
 ### Submitting pull requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apk add --update nodejs nodejs-npm make g++ git
 RUN npm install -g less less-plugin-clean-css
 RUN go get -u github.com/go-bindata/go-bindata/...
 
-RUN mkdir -p /go/src/github.com/writeas/writefreely
-WORKDIR /go/src/github.com/writeas/writefreely
+RUN mkdir -p /go/src/github.com/writefreely/writefreely
+WORKDIR /go/src/github.com/writefreely/writefreely
 
 COPY . .
 
@@ -16,11 +16,11 @@ RUN make build \
   && make ui
 RUN mkdir /stage && \
     cp -R /go/bin \
-      /go/src/github.com/writeas/writefreely/templates \
-      /go/src/github.com/writeas/writefreely/static \
-      /go/src/github.com/writeas/writefreely/pages \
-      /go/src/github.com/writeas/writefreely/keys \
-      /go/src/github.com/writeas/writefreely/cmd \
+      /go/src/github.com/writefreely/writefreely/templates \
+      /go/src/github.com/writefreely/writefreely/static \
+      /go/src/github.com/writefreely/writefreely/pages \
+      /go/src/github.com/writefreely/writefreely/keys \
+      /go/src/github.com/writefreely/writefreely/cmd \
       /stage
 
 # Final image

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GITREV=`git describe | cut -c 2-`
-LDFLAGS=-ldflags="-X 'github.com/writeas/writefreely.softwareVer=$(GITREV)'"
+LDFLAGS=-ldflags="-X 'github.com/writefreely/writefreely.softwareVer=$(GITREV)'"
 
 GOCMD=go
 GOINSTALL=$(GOCMD) install $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 </p>
 <hr />
 <p align="center">
-	<a href="https://github.com/writeas/writefreely/releases/">
+	<a href="https://github.com/writefreely/writefreely/releases/">
 		<img src="https://img.shields.io/github/release/writeas/writefreely.svg" alt="Latest release" />
 	</a>
 	<a href="https://travis-ci.org/writeas/writefreely">
 		<img src="https://travis-ci.org/writeas/writefreely.svg" alt="Build status" />
 	</a>
-	<a href="https://github.com/writeas/writefreely/releases/latest">
+	<a href="https://github.com/writefreely/writefreely/releases/latest">
 		<img src="https://img.shields.io/github/downloads/writeas/writefreely/total.svg" />
 	</a>
-	<a href="https://goreportcard.com/report/github.com/writeas/writefreely">
-		<img src="https://goreportcard.com/badge/github.com/writeas/writefreely" alt="Go Report Card" />
+	<a href="https://goreportcard.com/report/github.com/writefreely/writefreely">
+		<img src="https://goreportcard.com/badge/github.com/writefreely/writefreely" alt="Go Report Card" />
 	</a>
 	<a href="https://hub.docker.com/r/writeas/writefreely/">
 		<img src="https://img.shields.io/docker/pulls/writeas/writefreely.svg" />
@@ -62,7 +62,7 @@ The quickest way to deploy WriteFreely is with [Write.as](https://write.as/write
 
 WriteFreely deploys as a static binary on any platform and architecture that Go supports. Just use our built-in SQLite support, or add a MySQL database, and you'll be up and running!
 
-For common platforms, start with our [pre-built binaries](https://github.com/writeas/writefreely/releases/) and head over to our [installation guide](https://writefreely.org/start) to get started.
+For common platforms, start with our [pre-built binaries](https://github.com/writefreely/writefreely/releases/) and head over to our [installation guide](https://writefreely.org/start) to get started.
 
 ### Packages
 
@@ -80,10 +80,10 @@ Start hacking on WriteFreely with our [developer setup guide](https://writefreel
 
 ## Contributing
 
-We gladly welcome contributions to WriteFreely, whether in the form of [code](https://github.com/writeas/writefreely/blob/master/CONTRIBUTING.md#contributing-to-writefreely), [bug reports](https://github.com/writeas/writefreely/issues/new?template=bug_report.md), [feature requests](https://discuss.write.as/c/feedback/feature-requests), [translations](https://poeditor.com/join/project/TIZ6HFRFdE), or [documentation](https://github.com/writefreely/documentation) improvements.
+We gladly welcome contributions to WriteFreely, whether in the form of [code](https://github.com/writefreely/writefreely/blob/master/CONTRIBUTING.md#contributing-to-writefreely), [bug reports](https://github.com/writefreely/writefreely/issues/new?template=bug_report.md), [feature requests](https://discuss.write.as/c/feedback/feature-requests), [translations](https://poeditor.com/join/project/TIZ6HFRFdE), or [documentation](https://github.com/writefreely/documentation) improvements.
 
-Before contributing anything, please read our [Contributing Guide](https://github.com/writeas/writefreely/blob/master/CONTRIBUTING.md#contributing-to-writefreely). It describes the correct channels for submitting contributions and any potential requirements.
+Before contributing anything, please read our [Contributing Guide](https://github.com/writefreely/writefreely/blob/master/CONTRIBUTING.md#contributing-to-writefreely). It describes the correct channels for submitting contributions and any potential requirements.
 
 ## License
 
-Copyright © 2018-2020 [A Bunch Tell LLC](https://abunchtell.com) and contributing authors. Licensed under the [AGPL](https://github.com/writeas/writefreely/blob/develop/LICENSE).
+Copyright © 2018-2021 [A Bunch Tell LLC](https://abunchtell.com) and contributing authors. Licensed under the [AGPL](https://github.com/writefreely/writefreely/blob/develop/LICENSE).

--- a/account.go
+++ b/account.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -27,10 +27,9 @@ import (
 	"github.com/writeas/web-core/auth"
 	"github.com/writeas/web-core/data"
 	"github.com/writeas/web-core/log"
-
-	"github.com/writeas/writefreely/author"
-	"github.com/writeas/writefreely/config"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/author"
+	"github.com/writefreely/writefreely/config"
+	"github.com/writefreely/writefreely/page"
 )
 
 type (

--- a/admin.go
+++ b/admin.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -24,8 +24,8 @@ import (
 	"github.com/writeas/web-core/auth"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/web-core/passgen"
-	"github.com/writeas/writefreely/appstats"
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/appstats"
+	"github.com/writefreely/writefreely/config"
 )
 
 var (

--- a/app.go
+++ b/app.go
@@ -35,11 +35,11 @@ import (
 	"github.com/writeas/web-core/auth"
 	"github.com/writeas/web-core/converter"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/author"
-	"github.com/writeas/writefreely/config"
-	"github.com/writeas/writefreely/key"
-	"github.com/writeas/writefreely/migrations"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/author"
+	"github.com/writefreely/writefreely/config"
+	"github.com/writefreely/writefreely/key"
+	"github.com/writefreely/writefreely/migrations"
+	"github.com/writefreely/writefreely/page"
 	"golang.org/x/crypto/acme/autocert"
 )
 

--- a/author/author.go
+++ b/author/author.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -11,7 +11,7 @@
 package author
 
 import (
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/config"
 	"os"
 	"path/filepath"
 	"regexp"

--- a/cmd/writefreely/config.go
+++ b/cmd/writefreely/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 A Bunch Tell LLC.
+ * Copyright © 2020-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -11,9 +11,8 @@
 package main
 
 import (
-	"github.com/writeas/writefreely"
-
 	"github.com/urfave/cli/v2"
+	"github.com/writefreely/writefreely"
 )
 
 var (

--- a/cmd/writefreely/db.go
+++ b/cmd/writefreely/db.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 A Bunch Tell LLC.
+ * Copyright © 2020-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -11,9 +11,8 @@
 package main
 
 import (
-	"github.com/writeas/writefreely"
-
 	"github.com/urfave/cli/v2"
+	"github.com/writefreely/writefreely"
 )
 
 var (

--- a/cmd/writefreely/keys.go
+++ b/cmd/writefreely/keys.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 A Bunch Tell LLC.
+ * Copyright © 2020-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -11,9 +11,8 @@
 package main
 
 import (
-	"github.com/writeas/writefreely"
-
 	"github.com/urfave/cli/v2"
+	"github.com/writefreely/writefreely"
 )
 
 var (

--- a/cmd/writefreely/main.go
+++ b/cmd/writefreely/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -15,11 +15,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely"
-
 	"github.com/gorilla/mux"
 	"github.com/urfave/cli/v2"
+	"github.com/writeas/web-core/log"
+	"github.com/writefreely/writefreely"
 )
 
 func main() {

--- a/cmd/writefreely/user.go
+++ b/cmd/writefreely/user.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 A Bunch Tell LLC.
+ * Copyright © 2020-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -13,9 +13,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/writeas/writefreely"
-
 	"github.com/urfave/cli/v2"
+	"github.com/writefreely/writefreely"
 )
 
 var (

--- a/cmd/writefreely/web.go
+++ b/cmd/writefreely/web.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 A Bunch Tell LLC.
+ * Copyright © 2020-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -11,11 +11,10 @@
 package main
 
 import (
-	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely"
-
 	"github.com/gorilla/mux"
 	"github.com/urfave/cli/v2"
+	"github.com/writeas/web-core/log"
+	"github.com/writefreely/writefreely"
 )
 
 var (

--- a/collections.go
+++ b/collections.go
@@ -30,9 +30,9 @@ import (
 	"github.com/writeas/web-core/bots"
 	"github.com/writeas/web-core/log"
 	waposts "github.com/writeas/web-core/posts"
-	"github.com/writeas/writefreely/author"
-	"github.com/writeas/writefreely/config"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/author"
+	"github.com/writefreely/writefreely/config"
+	"github.com/writefreely/writefreely/page"
 )
 
 type (
@@ -240,7 +240,7 @@ func (c *Collection) DisplayCanonicalURL() string {
 func (c *Collection) RedirectingCanonicalURL(isRedir bool) string {
 	if c.hostName == "" {
 		// If this is true, the human programmers screwed up. So ask for a bug report and fail, fail, fail
-		log.Error("[PROGRAMMER ERROR] WARNING: Collection.hostName is empty! Federation and many other things will fail! If you're seeing this in the wild, please report this bug and let us know what you were doing just before this: https://github.com/writeas/writefreely/issues/new?template=bug_report.md")
+		log.Error("[PROGRAMMER ERROR] WARNING: Collection.hostName is empty! Federation and many other things will fail! If you're seeing this in the wild, please report this bug and let us know what you were doing just before this: https://github.com/writefreely/writefreely/issues/new?template=bug_report.md")
 	}
 	if isSingleUser {
 		return c.hostName + "/"

--- a/database.go
+++ b/database.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -15,7 +15,7 @@ import (
 	"database/sql"
 	"fmt"
 	"github.com/writeas/web-core/silobridge"
-	wf_db "github.com/writeas/writefreely/db"
+	wf_db "github.com/writefreely/writefreely/db"
 	"net/http"
 	"strings"
 	"time"
@@ -32,9 +32,9 @@ import (
 	"github.com/writeas/web-core/id"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/web-core/query"
-	"github.com/writeas/writefreely/author"
-	"github.com/writeas/writefreely/config"
-	"github.com/writeas/writefreely/key"
+	"github.com/writefreely/writefreely/author"
+	"github.com/writefreely/writefreely/config"
+	"github.com/writefreely/writefreely/key"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/writeas/writefreely
+module github.com/writefreely/writefreely
 
 require (
 	github.com/clbanning/mxj v1.8.4 // indirect

--- a/handle.go
+++ b/handle.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -24,8 +24,8 @@ import (
 	"github.com/prologic/go-gopher"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/config"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/config"
+	"github.com/writefreely/writefreely/page"
 )
 
 // UserLevel represents the required user level for accessing an endpoint
@@ -602,7 +602,7 @@ func (h *Handler) AllReader(f handlerFunc) http.HandlerFunc {
 			}()
 
 			// Allow any origin, as public endpoints are handled in here
-			w.Header().Set("Access-Control-Allow-Origin", "*");
+			w.Header().Set("Access-Control-Allow-Origin", "*")
 
 			if h.app.App().cfg.App.Private {
 				// This instance is private, so ensure it's being accessed by a valid user

--- a/invites.go
+++ b/invites.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 A Bunch Tell LLC.
+ * Copyright © 2019-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -21,7 +21,7 @@ import (
 	"github.com/writeas/impart"
 	"github.com/writeas/nerds/store"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/page"
 )
 
 type Invite struct {

--- a/keys.go
+++ b/keys.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2019, 2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -12,7 +12,7 @@ package writefreely
 
 import (
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/key"
+	"github.com/writefreely/writefreely/key"
 	"io/ioutil"
 	"os"
 	"path/filepath"

--- a/migrations/v4.go
+++ b/migrations/v4.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 A Bunch Tell LLC.
+ * Copyright © 2019-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -14,7 +14,7 @@ import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writeas/writefreely/db"
+	wf_db "github.com/writefreely/writefreely/db"
 )
 
 func oauth(db *datastore) error {

--- a/migrations/v5.go
+++ b/migrations/v5.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 A Bunch Tell LLC.
+ * Copyright © 2019-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -14,7 +14,7 @@ import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writeas/writefreely/db"
+	wf_db "github.com/writefreely/writefreely/db"
 )
 
 func oauthSlack(db *datastore) error {

--- a/migrations/v7.go
+++ b/migrations/v7.go
@@ -1,10 +1,20 @@
+/*
+ * Copyright © 2020-2021 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
 package migrations
 
 import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writeas/writefreely/db"
+	wf_db "github.com/writefreely/writefreely/db"
 )
 
 func oauthAttach(db *datastore) error {

--- a/migrations/v8.go
+++ b/migrations/v8.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 A Bunch Tell LLC.
+ * Copyright © 2020-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -14,7 +14,7 @@ import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writeas/writefreely/db"
+	wf_db "github.com/writefreely/writefreely/db"
 )
 
 func oauthInvites(db *datastore) error {

--- a/nodeinfo.go
+++ b/nodeinfo.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 A Bunch Tell LLC.
+ * Copyright © 2018-2019, 2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -12,8 +12,8 @@ package writefreely
 
 import (
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/config"
 	"github.com/writefreely/go-nodeinfo"
+	"github.com/writefreely/writefreely/config"
 	"strings"
 )
 
@@ -45,7 +45,7 @@ func nodeInfoConfig(db *datastore, cfg *config.Config) *nodeinfo.Config {
 			Private:         cfg.App.Private,
 			Software: nodeinfo.SoftwareMeta{
 				HomePage: softwareURL,
-				GitHub:   "https://github.com/writeas/writefreely",
+				GitHub:   "https://github.com/writefreely/writefreely",
 				Follow:   "https://writing.exchange/@write_as",
 			},
 			MaxBlogs:     cfg.App.MaxBlogs,

--- a/oauth.go
+++ b/oauth.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2019-2020 A Bunch Tell LLC.
+ * Copyright © 2019-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -25,7 +25,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/config"
 )
 
 // OAuthButtons holds display information for different OAuth providers we support.

--- a/oauth_signup.go
+++ b/oauth_signup.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 A Bunch Tell LLC.
+ * Copyright © 2020-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -17,7 +17,7 @@ import (
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/auth"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/page"
 	"html/template"
 	"net/http"
 	"strings"

--- a/oauth_test.go
+++ b/oauth_test.go
@@ -1,3 +1,13 @@
+/*
+ * Copyright © 2019-2021 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
 package writefreely
 
 import (
@@ -7,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/writeas/impart"
 	"github.com/writeas/nerds/store"
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/config"
 	"net/http"
 	"net/http/httptest"
 	"net/url"

--- a/pad.go
+++ b/pad.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -17,7 +17,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/page"
 )
 
 func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {

--- a/page/page.go
+++ b/page/page.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 A Bunch Tell LLC.
+ * Copyright © 2018-2019, 2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -12,7 +12,7 @@
 package page
 
 import (
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/config"
 	"strings"
 )
 

--- a/pages.go
+++ b/pages.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2019 A Bunch Tell LLC.
+ * Copyright © 2018-2019, 2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -12,7 +12,7 @@ package writefreely
 
 import (
 	"database/sql"
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/config"
 	"time"
 )
 

--- a/pages/500.tmpl
+++ b/pages/500.tmpl
@@ -2,7 +2,7 @@
 {{define "content"}}
 		<div class="content-container tight">
 			<h1>Server error &#x1F635;</h1>
-			<p>Please <a href="https://github.com/writeas/writefreely/issues/new">contact the human authors</a> of this software and remind them of their many shortcomings.</p>
+			<p>Please <a href="https://github.com/writefreely/writefreely/issues/new">contact the human authors</a> of this software and remind them of their many shortcomings.</p>
 			<p>Be gentle, though. They are fragile mortal beings.</p>
 			<p style="margin-top:2em">Also, unlike the AI that will soon replace them, you will need to include an error log from the server in your report. (Utterly <em>primitive</em>, we know.)</p>
 			<p>&ndash; {{.SiteName}} &#x1F916;</p>

--- a/postrender.go
+++ b/postrender.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -28,8 +28,8 @@ import (
 	blackfriday "github.com/writeas/saturday"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/web-core/stringmanip"
-	"github.com/writeas/writefreely/config"
-	"github.com/writeas/writefreely/parse"
+	"github.com/writefreely/writefreely/config"
+	"github.com/writefreely/writefreely/parse"
 )
 
 var (

--- a/posts.go
+++ b/posts.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -36,8 +36,8 @@ import (
 	"github.com/writeas/web-core/i18n"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/web-core/tags"
-	"github.com/writeas/writefreely/page"
-	"github.com/writeas/writefreely/parse"
+	"github.com/writefreely/writefreely/page"
+	"github.com/writefreely/writefreely/parse"
 )
 
 const (

--- a/posts_test.go
+++ b/posts_test.go
@@ -1,3 +1,13 @@
+/*
+ * Copyright © 2020-2021 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
 package writefreely_test
 
 import (
@@ -5,7 +15,7 @@ import (
 
 	"github.com/guregu/null/zero"
 	"github.com/stretchr/testify/assert"
-	"github.com/writeas/writefreely"
+	"github.com/writefreely/writefreely"
 )
 
 func TestPostSummary(t *testing.T) {

--- a/read.go
+++ b/read.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -25,7 +25,7 @@ import (
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/web-core/memo"
-	"github.com/writeas/writefreely/page"
+	"github.com/writefreely/writefreely/page"
 )
 
 const (

--- a/static/js/README.md
+++ b/static/js/README.md
@@ -17,7 +17,7 @@ Then [download an archive](https://github.com/highlightjs/highlight.js/releases)
 
 version=9.13.1
 
-cd $GOPATH/src/github.com/writeas/writefreely/static/js/highlightjs
+cd $GOPATH/src/github.com/writefreely/writefreely/static/js/highlightjs
 for f in $(ls ~/Downloads/highlight.js/src/languages); do
 	# Use minified versions
 	f=$(echo $f | sed 's/\.js/.min.js/')

--- a/templates.go
+++ b/templates.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -23,7 +23,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/writeas/web-core/l10n"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/config"
 )
 
 var (

--- a/templates/include/footer.tmpl
+++ b/templates/include/footer.tmpl
@@ -13,7 +13,7 @@
 				{{else}}
 					<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>
 					<a href="https://developers.write.as/" title="Build on WriteFreely with our open developer API.">developers</a>
-					<a href="https://github.com/writeas/writefreely">source code</a>
+					<a href="https://github.com/writefreely/writefreely">source code</a>
 					<a href="https://writefreely.org">writefreely {{.Version}}</a>
 				{{end}}
 			</nav>
@@ -33,7 +33,7 @@
 						<ul>
 							<li><a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a></li>
 							<li><a href="https://developers.write.as/" title="Build on WriteFreely with our open developer API.">developers</a></li>
-							<li><a href="https://github.com/writeas/writefreely">source code</a></li>
+							<li><a href="https://github.com/writefreely/writefreely">source code</a></li>
 							<li style="margin-top:0.8em">{{.Version}}</li>
 						</ul>
 					</div>

--- a/users.go
+++ b/users.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018 A Bunch Tell LLC.
+ * Copyright © 2018-2019, 2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -16,7 +16,7 @@ import (
 	"github.com/guregu/null/zero"
 	"github.com/writeas/web-core/data"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/key"
+	"github.com/writefreely/writefreely/key"
 )
 
 type UserStatus int

--- a/webfinger.go
+++ b/webfinger.go
@@ -19,7 +19,7 @@ import (
 	"github.com/writeas/go-webfinger"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/log"
-	"github.com/writeas/writefreely/config"
+	"github.com/writefreely/writefreely/config"
 )
 
 type wfResolver struct {


### PR DESCRIPTION
We've moved the repo from the `writeas` org on GitHub to `writefreely`.

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
