### PR TITLE
Do not create feed title for untitled posts

### DIFF
--- a/feed.go
+++ b/feed.go
@@ -97,7 +97,11 @@ func ViewFeed(app *App, w http.ResponseWriter, req *http.Request) error {
 
 	var title, permalink string
 	for _, p := range *coll.Posts {
-		title = p.PlainDisplayTitle()
+		if p.Title.String != "" {
+			title = p.PlainDisplayTitle()
+		} else {
+			title = ""
+		}
 		permalink = fmt.Sprintf("%s%s", baseUrl, p.Slug.String)
 		feed.Items = append(feed.Items, &Item{
 			Id:          fmt.Sprintf("%s%s", basePermalinkUrl, p.Slug.String),


### PR DESCRIPTION
Closes #455.

This PR changes the behaviour of feed.go to conditionally apply `p.PlainDisplayTitle()` only if the post's title is not an empty string.

---

- [ ] I have signed the [CLA](https://phabricator.write.as/L1)
