### PR TITLE
Support international domain names

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -33,6 +33,7 @@ import (
 	"github.com/writefreely/writefreely/author"
 	"github.com/writefreely/writefreely/config"
 	"github.com/writefreely/writefreely/page"
+	"golang.org/x/net/idna"
 )
 
 type (
@@ -236,7 +237,9 @@ func (c *Collection) DisplayCanonicalURL() string {
 	if p == "/" {
 		p = ""
 	}
-	return u.Hostname() + p
+	d := u.Hostname()
+	d, _ = idna.ToUnicode(d)
+	return d + p
 }
 
 func (c *Collection) RedirectingCanonicalURL(isRedir bool) string {

--- a/config/config.go
+++ b/config/config.go
@@ -267,9 +267,8 @@ func Load(fname string) (*Config, error) {
 		return nil, err
 	}
 	d, err := idna.ToASCII(u.Hostname())
-	log.Error("Host: %s", uc.App.Host)
 	if err != nil {
-		log.Error("ToASCII: %s", err)
+		log.Error("idna.ToASCII for %s: %s", u.Hostname(), err)
 		return nil, err
 	}
 	uc.App.Host = u.Scheme + "://" + d

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2018-2020 A Bunch Tell LLC.
+ * Copyright © 2018-2021 A Bunch Tell LLC.
  *
  * This file is part of WriteFreely.
  *
@@ -12,8 +12,11 @@
 package config
 
 import (
+	"net/url"
 	"strings"
 
+	"github.com/writeas/web-core/log"
+	"golang.org/x/net/idna"
 	"gopkg.in/ini.v1"
 )
 
@@ -257,6 +260,23 @@ func Load(fname string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// Do any transformations
+	u, err := url.Parse(uc.App.Host)
+	if err != nil {
+		return nil, err
+	}
+	d, err := idna.ToASCII(u.Hostname())
+	log.Error("Host: %s", uc.App.Host)
+	if err != nil {
+		log.Error("ToASCII: %s", err)
+		return nil, err
+	}
+	uc.App.Host = u.Scheme + "://" + d
+	if u.Port() != "" {
+		uc.App.Host += ":" + u.Port()
+	}
+
 	return uc, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/writeas/web-core v1.3.1-0.20210330164422-95a3a717ed8f
 	github.com/writefreely/go-nodeinfo v1.2.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/net v0.0.0-20200707034311-ab3426394381 // indirect
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	gopkg.in/ini.v1 v1.62.0
 )
 


### PR DESCRIPTION
This internally converts the configured host name into its Punycode ASCII representation, while showing users the correct Unicode domain name. It enables admins to host a WriteFreely instance at a domain like https://bär.writefreely.dev (Punycode: https://xn--br-via.writefreely.dev).

Tested and verified this works in the fediverse. Demo post: https://xn--br-via.writefreely.dev/testing-non-ascii-domains

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
