### PR TITLE
Fix Gopher links and add blog info

### DIFF
--- a/gopher.go
+++ b/gopher.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -31,7 +32,12 @@ func initGopher(apper Apper) {
 
 // Utility function to strip the URL from the hostname provided by app.cfg.App.Host
 func stripHostProtocol(app *App) string {
-	return string(regexp.MustCompile("^.*://").ReplaceAll([]byte(app.cfg.App.Host), []byte("")))
+	u, err := url.Parse(app.cfg.App.Host)
+	if err != nil {
+		// Fall back to host, with scheme stripped
+		return string(regexp.MustCompile("^.*://").ReplaceAll([]byte(app.cfg.App.Host), []byte("")))
+	}
+	return u.Hostname()
 }
 
 func handleGopher(app *App, w gopher.ResponseWriter, r *gopher.Request) error {

--- a/gopher.go
+++ b/gopher.go
@@ -106,6 +106,11 @@ func handleGopherCollection(app *App, w gopher.ResponseWriter, r *gopher.Request
 	}
 	c.hostName = app.cfg.App.Host
 
+	w.WriteInfo(c.DisplayTitle())
+	if c.Description != "" {
+		w.WriteInfo(c.Description)
+	}
+
 	posts, err := app.db.GetPosts(app.cfg, c, 0, false, false, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, if running an instance on e.g. `http://localhost:8080`, the HTTP port would show up in the Gopher links and potentially cause rendering to fail. This fixes that.

It also adds blog information (title and description) to blogs when viewed via Gopher.

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
