### PR TITLE
Final API changes

### DIFF
--- a/database.go
+++ b/database.go
@@ -875,7 +875,7 @@ func (db *datastore) UpdateCollection(c *SubmittedCollection, alias string) erro
 	// WHERE values
 	q.Where("alias = ? AND owner_id = ?", alias, c.OwnerID)
 
-	if q.Updates == "" {
+	if q.Updates == "" && c.Monetization == nil {
 		return ErrPostNoUpdatableVals
 	}
 
@@ -932,10 +932,12 @@ func (db *datastore) UpdateCollection(c *SubmittedCollection, alias string) erro
 	}
 
 	// Update rest of the collection data
-	res, err = db.Exec("UPDATE collections SET "+q.Updates+" WHERE "+q.Conditions, q.Params...)
-	if err != nil {
-		log.Error("Unable to update collection: %v", err)
-		return err
+	if q.Updates != "" {
+		res, err = db.Exec("UPDATE collections SET "+q.Updates+" WHERE "+q.Conditions, q.Params...)
+		if err != nil {
+			log.Error("Unable to update collection: %v", err)
+			return err
+		}
 	}
 
 	rowsAffected, _ = res.RowsAffected()

--- a/pad.go
+++ b/pad.go
@@ -90,6 +90,7 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 		}
 		appData.EditCollection, err = app.db.GetCollectionForPad(collAlias)
 		if err != nil {
+			log.Error("Unable to GetCollectionForPad: %s", err)
 			return err
 		}
 		appData.EditCollection.hostName = app.cfg.App.Host
@@ -101,9 +102,10 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 
 	if appData.Post.Gone {
 		return ErrPostUnpublished
-	} else if appData.Post.Found && appData.Post.Content != "" {
+	} else if appData.Post.Found && (appData.Post.Title != "" || appData.Post.Content != "") {
 		// Got the post
 	} else if appData.Post.Found {
+		log.Error("Found post, but other conditions failed.")
 		return ErrPostFetchError
 	} else {
 		return ErrPostNotFound

--- a/posts.go
+++ b/posts.go
@@ -397,7 +397,7 @@ func handleViewPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// Check if post has been unpublished
-	if content == "" {
+	if title == "" && content == "" {
 		gone = true
 
 		if isJSON {
@@ -546,9 +546,14 @@ func newPost(app *App, w http.ResponseWriter, r *http.Request) error {
 			t := ""
 			p.Title = &t
 		}
-		if strings.TrimSpace(*(p.Content)) == "" {
+		if strings.TrimSpace(*(p.Title)) == "" && (p.Content == nil || strings.TrimSpace(*(p.Content)) == "") {
 			return ErrNoPublishableContent
 		}
+		if p.Content == nil {
+			c := ""
+			p.Content = &c
+		}
+
 	} else {
 		post := r.FormValue("body")
 		appearance := r.FormValue("font")
@@ -1260,10 +1265,22 @@ func getRawPost(app *App, friendlyID string) *RawPost {
 	case err == sql.ErrNoRows:
 		return &RawPost{Content: "", Found: false, Gone: false}
 	case err != nil:
+		log.Error("Unable to fetch getRawPost: %s", err)
 		return &RawPost{Content: "", Found: true, Gone: false}
 	}
 
-	return &RawPost{Title: title, Content: content, Font: font, Created: created, Updated: updated, IsRTL: isRTL, Language: lang, OwnerID: ownerID.Int64, Found: true, Gone: content == ""}
+	return &RawPost{
+		Title:    title,
+		Content:  content,
+		Font:     font,
+		Created:  created,
+		Updated:  updated,
+		IsRTL:    isRTL,
+		Language: lang,
+		OwnerID:  ownerID.Int64,
+		Found:    true,
+		Gone:     content == "" && title == "",
+	}
 
 }
 
@@ -1286,6 +1303,7 @@ func getRawCollectionPost(app *App, slug, collAlias string) *RawPost {
 	case err == sql.ErrNoRows:
 		return &RawPost{Content: "", Found: false, Gone: false}
 	case err != nil:
+		log.Error("Unable to fetch getRawCollectionPost: %s", err)
 		return &RawPost{Content: "", Found: true, Gone: false}
 	}
 
@@ -1301,7 +1319,7 @@ func getRawCollectionPost(app *App, slug, collAlias string) *RawPost {
 		Language: lang,
 		OwnerID:  ownerID.Int64,
 		Found:    true,
-		Gone:     content == "",
+		Gone:     content == "" && title == "",
 		Views:    views,
 	}
 }

--- a/posts.go
+++ b/posts.go
@@ -125,6 +125,7 @@ type (
 		Views       int64          `json:"views"`
 		Owner       *PublicUser    `json:"-"`
 		IsOwner     bool           `json:"-"`
+		URL         string         `json:"url,omitempty"`
 		Collection  *CollectionObj `json:"collection,omitempty"`
 	}
 
@@ -612,6 +613,7 @@ func newPost(app *App, w http.ResponseWriter, r *http.Request) error {
 
 	newPost.extractData()
 	newPost.OwnerName = username
+	newPost.URL = newPost.CanonicalURL(app.cfg.App.Host)
 
 	// Write success now
 	response := impart.WriteSuccess(w, newPost, http.StatusCreated)
@@ -1124,7 +1126,7 @@ func (p *Post) processPost() PublicPost {
 
 func (p *PublicPost) CanonicalURL(hostName string) string {
 	if p.Collection == nil || p.Collection.Alias == "" {
-		return hostName + "/" + p.ID
+		return hostName + "/" + p.ID + ".md"
 	}
 	return p.Collection.CanonicalURL() + p.Slug.String
 }

--- a/read.go
+++ b/read.go
@@ -315,7 +315,6 @@ func viewLocalTimelineFeed(app *App, w http.ResponseWriter, req *http.Request) e
 			author = p.Collection.Title
 		} else {
 			author = "Anonymous"
-			permalink += ".md"
 		}
 		i := &Item{
 			Id:          app.cfg.App.Host + "/read/a/" + p.ID,

--- a/templates/classic.tmpl
+++ b/templates/classic.tmpl
@@ -283,7 +283,7 @@
 		*/
 		$btnPublish.on('click', function(e) {
 			e.preventDefault();
-			if (!publishing && $content.el.value) {
+			if (!publishing && ($title.el.value || $content.el.value)) {
 				var title = $title.el.value;
 				var content = $content.el.value;
 				publish(title, content, selectedFont);


### PR DESCRIPTION
This makes a few API changes first implemented on our Write.as instance to support a large multi-user migration. Changes:

* *Publish a Post* endpoint: return a `url` property of the final post URL
* Support updating collections only with a `monetization_pointer` field supplied
* Support publishing posts with only a title

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
