### PR TITLE
Don't render title as list item

### DIFF
--- a/postrender.go
+++ b/postrender.go
@@ -11,6 +11,7 @@
 package writefreely
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"html"
@@ -191,7 +192,12 @@ func applyBasicMarkdown(data []byte) string {
 		blackfriday.HTML_SMARTYPANTS_DASHES
 
 	// Generate Markdown
-	md := blackfriday.Markdown([]byte(data), blackfriday.HtmlRenderer(htmlFlags, "", ""), mdExtensions)
+	// This passes the supplied title into blackfriday.Markdown() as an H1 header, so we only render HTML that
+	// belongs in an H1.
+	md := blackfriday.Markdown(append([]byte("# "), data...), blackfriday.HtmlRenderer(htmlFlags, "", ""), mdExtensions)
+	// Remove H1 markup
+	md = bytes.TrimSpace(md) // blackfriday.Markdown adds a newline at the end of the <h1>
+	md = md[len("<h1>") : len(md)-len("</h1>")]
 	// Strip out bad HTML
 	policy := bluemonday.UGCPolicy()
 	policy.AllowAttrs("class", "id").Globally()

--- a/postrender.go
+++ b/postrender.go
@@ -182,7 +182,7 @@ func applyMarkdownSpecial(data []byte, skipNoFollow bool, baseURL string, cfg *c
 }
 
 func applyBasicMarkdown(data []byte) string {
-	if len(data) == 0 {
+	if len(bytes.TrimSpace(data)) == 0 {
 		return ""
 	}
 

--- a/postrender.go
+++ b/postrender.go
@@ -182,6 +182,10 @@ func applyMarkdownSpecial(data []byte, skipNoFollow bool, baseURL string, cfg *c
 }
 
 func applyBasicMarkdown(data []byte) string {
+	if len(data) == 0 {
+		return ""
+	}
+
 	mdExtensions := 0 |
 		blackfriday.EXTENSION_STRIKETHROUGH |
 		blackfriday.EXTENSION_SPACE_HEADERS |

--- a/postrender_test.go
+++ b/postrender_test.go
@@ -18,6 +18,7 @@ func TestApplyBasicMarkdown(t *testing.T) {
 		in     string
 		result string
 	}{
+		{"empty", "", ""},
 		{"plain", "Hello, World!", "Hello, World!"},
 		{"multibyte", "こんにちは", `こんにちは`},
 		{"bold", "**안녕하세요**", `<strong>안녕하세요</strong>`},

--- a/postrender_test.go
+++ b/postrender_test.go
@@ -19,6 +19,12 @@ func TestApplyBasicMarkdown(t *testing.T) {
 		result string
 	}{
 		{"empty", "", ""},
+		{"empty spaces", "  ", ""},
+		{"empty tabs", "\t", ""},
+		{"empty newline", "\n", ""},
+		{"nums", "123", "123"},
+		{"dot", ".", "."},
+		{"dash", "-", "-"},
 		{"plain", "Hello, World!", "Hello, World!"},
 		{"multibyte", "こんにちは", `こんにちは`},
 		{"bold", "**안녕하세요**", `<strong>안녕하세요</strong>`},

--- a/postrender_test.go
+++ b/postrender_test.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2021 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package writefreely
+
+import "testing"
+
+func TestApplyBasicMarkdown(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		result string
+	}{
+		{"plain", "Hello, World!", "Hello, World!"},
+		{"multibyte", "こんにちは", `こんにちは`},
+		{"bold", "**안녕하세요**", `<strong>안녕하세요</strong>`},
+		{"link", "[WriteFreely](https://writefreely.org)", `<a href="https://writefreely.org" rel="nofollow">WriteFreely</a>`},
+		{"date", "12. April", `12. April`},
+		{"table", "| Hi | There |", `| Hi | There |`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := applyBasicMarkdown([]byte(test.in))
+			if res != test.result {
+				t.Errorf("%s: wanted %s, got %s", test.name, test.result, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes an issue where "12. April" would get rendered as "1. April" because it looks like a Markdown list item to our renderer. Now, we parse titles as titles, instead of standalone text, which causes the renderer to give us the results we want. This also adds some basic tests for the `applyBasicMarkdown()` func.

Closes #470

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
