### PR TITLE
Remove additional slash in /feed/ redirect

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -242,6 +242,8 @@ func (c *Collection) DisplayCanonicalURL() string {
 	return d + p
 }
 
+// RedirectingCanonicalURL returns the fully-qualified canonical URL for the Collection, with a trailing slash. The
+// hostName field needs to be populated for this to work correctly.
 func (c *Collection) RedirectingCanonicalURL(isRedir bool) string {
 	if c.hostName == "" {
 		// If this is true, the human programmers screwed up. So ask for a bug report and fail, fail, fail

--- a/posts.go
+++ b/posts.go
@@ -1461,7 +1461,7 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 			if slug == "feed" {
 				// User tried to access blog feed without a trailing slash, and
 				// there's no post with a slug "feed"
-				return impart.HTTPError{http.StatusFound, c.CanonicalURL() + "/feed/"}
+				return impart.HTTPError{http.StatusFound, c.CanonicalURL() + "feed/"}
 			}
 
 			po := &Post{


### PR DESCRIPTION
This fixes an issue with blogs redirecting to `https://instance.tld/user//feed/` (with an additional slash), as reported [on the forum](https://discuss.write.as/t/rss-feeds-are-broken/2949).

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
