### PR TITLE
Fix SQLite database lock on Reader

### DIFF
--- a/app.go
+++ b/app.go
@@ -797,7 +797,7 @@ func connectToDatabase(app *App) {
 			os.Exit(1)
 		}
 		db, err = sql.Open("sqlite3_with_regex", app.cfg.Database.FileName+"?parseTime=true&cached=shared")
-		db.SetMaxOpenConns(1)
+		db.SetMaxOpenConns(2)
 	} else {
 		log.Error("Invalid database type '%s'. Only 'mysql' and 'sqlite3' are supported right now.", app.cfg.Database.Type)
 		os.Exit(1)


### PR DESCRIPTION
Fetching posts for the Reader involves an additional query on each row, which previously ran into our connection limit to the database and caused it to lock up. This increases the connection limit from 1 to 2, to allow this.

This is meant to be a quick, safe fix, but there could always be a better solution.

Fixes #467

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
