### PR TITLE
Remove rel=nofollow attribute in certain situations

### DIFF
--- a/postrender.go
+++ b/postrender.go
@@ -119,7 +119,7 @@ func (p *PublicPost) augmentReadingDestination() {
 }
 
 func applyMarkdown(data []byte, baseURL string, cfg *config.Config) string {
-	return applyMarkdownSpecial(data, false, baseURL, cfg)
+	return applyMarkdownSpecial(data, baseURL, cfg, false)
 }
 
 func disableYoutubeAutoplay(outHTML string) string {
@@ -141,7 +141,7 @@ func disableYoutubeAutoplay(outHTML string) string {
 	return outHTML
 }
 
-func applyMarkdownSpecial(data []byte, skipNoFollow bool, baseURL string, cfg *config.Config) string {
+func applyMarkdownSpecial(data []byte, baseURL string, cfg *config.Config, skipNoFollow bool) string {
 	mdExtensions := 0 |
 		blackfriday.EXTENSION_TABLES |
 		blackfriday.EXTENSION_FENCED_CODE |

--- a/postrender.go
+++ b/postrender.go
@@ -119,7 +119,7 @@ func (p *PublicPost) augmentReadingDestination() {
 }
 
 func applyMarkdown(data []byte, baseURL string, cfg *config.Config) string {
-	return applyMarkdownSpecial(data, baseURL, cfg, false)
+	return applyMarkdownSpecial(data, baseURL, cfg, cfg.App.SingleUser)
 }
 
 func disableYoutubeAutoplay(outHTML string) string {


### PR DESCRIPTION
Previously, WriteFreely always applied `rel="nofollow"` on all blog links, since posts on multi-user instances are published by untrusted users, and this helps protect such instances' reputation with search engines. This change alters that behavior by _not_ applying `rel="nofollow"` if the instance is set to single-user mode, since we can assume that all content is trusted, then. When merged, it will close #314.

Still to do:

- [ ] Allow user to manually add `rel` attributes on HTML links

Still up for discussion:

* Should we use any other signals to determine whether or not to disable `rel="nofollow"`?
* Is there a reason we might add an explicit configuration option for this? Or could we leverage another one for that?

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
