### PR TITLE
Log user out when authenticated as deleted user

### DIFF
--- a/account.go
+++ b/account.go
@@ -787,6 +787,9 @@ func viewArticles(app *App, u *User, w http.ResponseWriter, r *http.Request) err
 
 	silenced, err := app.db.IsUserSilenced(u.ID)
 	if err != nil {
+		if err == ErrUserNotFound {
+			return err
+		}
 		log.Error("view articles: %v", err)
 	}
 	d := struct {
@@ -822,7 +825,10 @@ func viewCollections(app *App, u *User, w http.ResponseWriter, r *http.Request) 
 
 	silenced, err := app.db.IsUserSilenced(u.ID)
 	if err != nil {
-		log.Error("view collections %v", err)
+		if err == ErrUserNotFound {
+			return err
+		}
+		log.Error("view collections: %v", err)
 		return fmt.Errorf("view collections: %v", err)
 	}
 	d := struct {
@@ -861,6 +867,9 @@ func viewEditCollection(app *App, u *User, w http.ResponseWriter, r *http.Reques
 
 	silenced, err := app.db.IsUserSilenced(u.ID)
 	if err != nil {
+		if err == ErrUserNotFound {
+			return err
+		}
 		log.Error("view edit collection %v", err)
 		return fmt.Errorf("view edit collection: %v", err)
 	}
@@ -1037,6 +1046,9 @@ func viewStats(app *App, u *User, w http.ResponseWriter, r *http.Request) error 
 
 	silenced, err := app.db.IsUserSilenced(u.ID)
 	if err != nil {
+		if err == ErrUserNotFound {
+			return err
+		}
 		log.Error("view stats: %v", err)
 		return err
 	}
@@ -1070,6 +1082,9 @@ func viewStats(app *App, u *User, w http.ResponseWriter, r *http.Request) error 
 func viewSettings(app *App, u *User, w http.ResponseWriter, r *http.Request) error {
 	fullUser, err := app.db.GetUserByID(u.ID)
 	if err != nil {
+		if err == ErrUserNotFound {
+			return err
+		}
 		log.Error("Unable to get user for settings: %s", err)
 		return impart.HTTPError{http.StatusInternalServerError, "Unable to retrieve user data. The humans have been alerted."}
 	}

--- a/database.go
+++ b/database.go
@@ -332,7 +332,7 @@ func (db *datastore) IsUserSilenced(id int64) (bool, error) {
 	err := db.QueryRow("SELECT status FROM users WHERE id = ?", id).Scan(&u.Status)
 	switch {
 	case err == sql.ErrNoRows:
-		return false, fmt.Errorf("is user silenced: %v", ErrUserNotFound)
+		return false, ErrUserNotFound
 	case err != nil:
 		log.Error("Couldn't SELECT user status: %v", err)
 		return false, fmt.Errorf("is user silenced: %v", err)

--- a/handle.go
+++ b/handle.go
@@ -155,8 +155,14 @@ func (h *Handler) User(f userHandlerFunc) http.HandlerFunc {
 			err := f(h.app.App(), u, w, r)
 			if err == nil {
 				status = http.StatusOK
-			} else if err, ok := err.(impart.HTTPError); ok {
-				status = err.Status
+			} else if impErr, ok := err.(impart.HTTPError); ok {
+				status = impErr.Status
+				if impErr == ErrUserNotFound {
+					log.Info("Logged-in user not found. Logging out.")
+					sendRedirect(w, http.StatusFound, "/me/logout?to="+h.app.App().cfg.App.LandingPath())
+					// Reset err so handleHTTPError does nothing
+					err = nil
+				}
 			} else {
 				status = http.StatusInternalServerError
 			}

--- a/invites.go
+++ b/invites.go
@@ -78,6 +78,9 @@ func handleViewUserInvites(app *App, u *User, w http.ResponseWriter, r *http.Req
 
 	p.Silenced, err = app.db.IsUserSilenced(u.ID)
 	if err != nil {
+		if err == ErrUserNotFound {
+			return err
+		}
 		log.Error("view invites: %v", err)
 	}
 

--- a/pad.go
+++ b/pad.go
@@ -55,6 +55,9 @@ func handleViewPad(app *App, w http.ResponseWriter, r *http.Request) error {
 		}
 		appData.Silenced, err = app.db.IsUserSilenced(appData.User.ID)
 		if err != nil {
+			if err == ErrUserNotFound {
+				return err
+			}
 			log.Error("Unable to get user status for Pad: %v", err)
 		}
 	}

--- a/session.go
+++ b/session.go
@@ -130,12 +130,13 @@ func saveUserSession(app *App, r *http.Request, w http.ResponseWriter) error {
 	return err
 }
 
-func getFullUserSession(app *App, r *http.Request) *User {
+func getFullUserSession(app *App, r *http.Request) (*User, error) {
 	u := getUserSession(app, r)
 	if u == nil {
-		return nil
+		return nil, nil
 	}
 
-	u, _ = app.db.GetUserByID(u.ID)
-	return u
+	var err error
+	u, err = app.db.GetUserByID(u.ID)
+	return u, err
 }


### PR DESCRIPTION
Now when we check for the user at certain times and find that the user doesn't exist in the database, we log them out and send them back to the home page.

Previously, this could happen when e.g. the user is logged in on multiple browsers and then deletes their account -- they'll be logged out in the browser they deleted from, but not from other browser sessions.

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
