### PR TITLE
Fix Gopher collections query

### DIFF
--- a/database.go
+++ b/database.go
@@ -1688,7 +1688,7 @@ func (db *datastore) GetPublicCollections(hostName string) (*[]Collection, error
 	FROM collections c
 	LEFT JOIN users u ON u.id = c.owner_id
 	WHERE c.privacy = 1 AND u.status = 0
-	ORDER BY id ASC`)
+	ORDER BY title ASC`)
 	if err != nil {
 		log.Error("Failed selecting public collections: %v", err)
 		return nil, impart.HTTPError{http.StatusInternalServerError, "Couldn't retrieve public collections."}


### PR DESCRIPTION
Accessing to the Writefreely instance via Gopher throws this error:

```
ERROR: 2021/08/05 13:47:47 database.go:1693: Failed selecting public collections: ambiguous column name: id
ERROR: 2021/08/05 13:47:47 handle.go:990: failed: Couldn't retrieve public collections.
```

Instead of changing it to ORDER BY c.id it seems to make more sense ordering the collection by title instead.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
