### PR TITLE
fix Dockerfile, nodejs-npm was renamed in alpine to npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build image
 FROM golang:1.15-alpine as build
 
-RUN apk add --update nodejs nodejs-npm make g++ git
+RUN apk add --update nodejs npm make g++ git
 RUN npm install -g less less-plugin-clean-css
 RUN go get -u github.com/go-bindata/go-bindata/...
 


### PR DESCRIPTION
docker builds failed because alpine renamed the nodejs-npm package to npm, this pr should fix it ;)

 * [x]  I have signed the [CLA](https://phabricator.write.as/L1)