### PR TITLE
Templates: use relative URLs for static assets

### DIFF
--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -2,8 +2,8 @@
 <html>
 	<head>
 		{{ template "head" . }}
-		<link rel="stylesheet" type="text/css" href="{{.Host}}/css/{{.Theme}}.css" />
-		<link rel="shortcut icon" href="{{.Host}}/favicon.ico" />
+		<link rel="stylesheet" type="text/css" href="/css/{{.Theme}}.css" />
+		<link rel="shortcut icon" href="/favicon.ico" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 		<meta name="application-name" content="{{.SiteName}}">
@@ -86,7 +86,7 @@
 		{{end}}
 		</script>
 		{{else}}
-			{{if .WebFonts}}<link href="{{.Host}}/css/fonts.css" rel="stylesheet" type="text/css" />{{end}}
+			{{if .WebFonts}}<link href="/css/fonts.css" rel="stylesheet" type="text/css" />{{end}}
 		{{end}}
 	</body>
 </html>{{end}}


### PR DESCRIPTION
I noticed most asset links use relative URLs, except for a few. This commit remedies this inconsistency. OpenGraph embeds were not changed, because in my experience, some embed scrapers require absolute URLs.

Motivation: The site I use has an onion and a clearnet site, and currently, visiting the onion loads fonts, styles, and the favicon
over the clearnet.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
