### PR TITLE
Support filtering blog posts by language

### DIFF
--- a/database.go
+++ b/database.go
@@ -1260,6 +1260,61 @@ func (db *datastore) GetPostsTagged(cfg *config.Config, c *Collection, tag strin
 	return &posts, nil
 }
 
+func (db *datastore) GetLangPosts(cfg *config.Config, c *Collection, lang string, page int, includeFuture bool) (*[]PublicPost, error) {
+	collID := c.ID
+
+	cf := c.NewFormat()
+	order := "DESC"
+	if cf.Ascending() {
+		order = "ASC"
+	}
+
+	pagePosts := cf.PostsPerPage()
+	start := page*pagePosts - pagePosts
+	if page == 0 {
+		start = 0
+		pagePosts = 1000
+	}
+
+	limitStr := ""
+	if page > 0 {
+		limitStr = fmt.Sprintf(" LIMIT %d, %d", start, pagePosts)
+	}
+	timeCondition := ""
+	if !includeFuture {
+		timeCondition = "AND created <= " + db.now()
+	}
+
+	rows, err := db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND language = ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, lang)
+	if err != nil {
+		log.Error("Failed selecting from posts: %v", err)
+		return nil, impart.HTTPError{http.StatusInternalServerError, "Couldn't retrieve collection posts."}
+	}
+	defer rows.Close()
+
+	// TODO: extract this common row scanning logic for queries using `postCols`
+	posts := []PublicPost{}
+	for rows.Next() {
+		p := &Post{}
+		err = rows.Scan(&p.ID, &p.Slug, &p.Font, &p.Language, &p.RTL, &p.Privacy, &p.OwnerID, &p.CollectionID, &p.PinnedPosition, &p.Created, &p.Updated, &p.ViewCount, &p.Title, &p.Content)
+		if err != nil {
+			log.Error("Failed scanning row: %v", err)
+			break
+		}
+		p.extractData()
+		p.augmentContent(c)
+		p.formatContent(cfg, c, includeFuture, false)
+
+		posts = append(posts, p.processPost())
+	}
+	err = rows.Err()
+	if err != nil {
+		log.Error("Error after Next() on rows: %v", err)
+	}
+
+	return &posts, nil
+}
+
 func (db *datastore) GetAPFollowers(c *Collection) (*[]RemoteUser, error) {
 	rows, err := db.Query("SELECT actor_id, inbox, shared_inbox FROM remotefollows f INNER JOIN remoteusers u ON f.remote_user_id = u.id WHERE collection_id = ?", c.ID)
 	if err != nil {

--- a/routes.go
+++ b/routes.go
@@ -216,6 +216,7 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 func RouteCollections(handler *Handler, r *mux.Router) {
 	r.HandleFunc("/logout", handler.Web(handleLogOutCollection, UserLevelOptional))
 	r.HandleFunc("/page/{page:[0-9]+}", handler.Web(handleViewCollection, UserLevelReader))
+	r.HandleFunc("/lang:{lang}", handler.Web(handleViewCollectionLang, UserLevelOptional))
 	r.HandleFunc("/tag:{tag}", handler.Web(handleViewCollectionTag, UserLevelReader))
 	r.HandleFunc("/tag:{tag}/feed/", handler.Web(ViewFeed, UserLevelReader))
 	r.HandleFunc("/sitemap.xml", handler.AllReader(handleViewSitemap))


### PR DESCRIPTION
This enables readers to filter blog posts by language. To do so, navigate to `https://instance.tld/username/lang:en`, where `en` is the two-digit language code.

When finished, this closes [T805](https://writefreely.org/tasks/805). See that task for work left here.

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
