### PR TITLE
Hotfix/accessibility

### DIFF
--- a/pages/landing.tmpl
+++ b/pages/landing.tmpl
@@ -88,17 +88,17 @@ form dd {
 					<label>
 						<dt>Username</dt>
 						<dd>
-							<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" tabindex="1" autofocus {{if .ForcedLanding}}disabled{{end}} />
+							<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" autofocus {{if .ForcedLanding}}disabled{{end}} />
 							{{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
 						</dd>
 					</label>
 					<label>
 						<dt>Password</dt>
-						<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" tabindex="2" style="width: 100%; box-sizing: border-box;" {{if .ForcedLanding}}disabled{{end}} /></dd>
+						<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" style="width: 100%; box-sizing: border-box;" {{if .ForcedLanding}}disabled{{end}} /></dd>
 					</label>
 					<label>
 						<dt>Email (optional)</dt>
-						<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" tabindex="3" {{if .ForcedLanding}}disabled{{end}} /></dd>
+						<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" {{if .ForcedLanding}}disabled{{end}} /></dd>
 					</label>
 					<dt>
 						<button id="btn-create" type="submit" style="margin-top: 0" {{if .ForcedLanding}}disabled{{end}}>Create blog</button>

--- a/pages/landing.tmpl
+++ b/pages/landing.tmpl
@@ -85,21 +85,15 @@ form dd {
 		<div id="billing">
 			<form action="/auth/signup" method="POST" id="signup-form" onsubmit="return signup()">
 				<dl class="billing">
-					<label>
-						<dt>Username</dt>
-						<dd>
-							<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" autofocus {{if .ForcedLanding}}disabled{{end}} />
-							{{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
-						</dd>
-					</label>
-					<label>
-						<dt>Password</dt>
-						<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" style="width: 100%; box-sizing: border-box;" {{if .ForcedLanding}}disabled{{end}} /></dd>
-					</label>
-					<label>
-						<dt>Email (optional)</dt>
-						<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" {{if .ForcedLanding}}disabled{{end}} /></dd>
-					</label>
+					<dt><label for="alias">Username</label></dt>
+					<dd>
+						<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" autofocus {{if .ForcedLanding}}disabled{{end}} />
+						{{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
+					</dd>
+					<dt><label for="password">Password</label></dt>
+					<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" style="width: 100%; box-sizing: border-box;" {{if .ForcedLanding}}disabled{{end}} /></dd>
+					<dt><label for="email">Email (optional)</label></dt>
+					<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" {{if .ForcedLanding}}disabled{{end}} /></dd>
 					<dt>
 						<button id="btn-create" type="submit" style="margin-top: 0" {{if .ForcedLanding}}disabled{{end}}>Create blog</button>
 					</dt>

--- a/pages/signup-oauth.tmpl
+++ b/pages/signup-oauth.tmpl
@@ -75,25 +75,19 @@ form dd {
 	        {{if .InviteCode}}<input type="hidden" name="invite_code" value="{{ .InviteCode }}" />{{end}}
 
             <dl class="billing">
-                <label>
-                    <dt>Display Name</dt>
-                    <dd>
-                        <input type="text" style="width: 100%; box-sizing: border-box;" name="alias" placeholder="Name"{{ if .Alias }} value="{{.Alias}}"{{ end }} />
-                    </dd>
-                </label>
-                <label>
-                    <dt>Username</dt>
-					<dd>
-		<input type="text" id="username" name="username" style="width: 100%; box-sizing: border-box;" placeholder="Username" value="{{.LoginUsername}}" /><br />
-		{{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
-                    </dd>
-                </label>
-                <label>
-                    <dt>Email</dt>
-                    <dd>
-<input type="text" name="email" style="width: 100%; box-sizing: border-box;" placeholder="Email"{{ if .Email }} value="{{.Email}}"{{ end }} />
-                    </dd>
-                </label>
+                <dt><label for="alias">Display Name</label></dt>
+                <dd>
+                    <input type="text" style="width: 100%; box-sizing: border-box;" name="alias" placeholder="Name"{{ if .Alias }} value="{{.Alias}}"{{ end }} />
+                </dd>
+                <dt><label for="username">Username</label></dt>
+                <dd>
+                    <input type="text" id="username" name="username" style="width: 100%; box-sizing: border-box;" placeholder="Username" value="{{.LoginUsername}}" /><br />
+                    {{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
+                </dd>
+                <dt><label for="email">Email</label></dt>
+                <dd>
+                    <input type="text" name="email" style="width: 100%; box-sizing: border-box;" placeholder="Email"{{ if .Email }} value="{{.Email}}"{{ end }} />
+                </dd>
                 <dt>
                     <input type="submit" id="btn-login" value="Next" />
                 </dt>

--- a/pages/signup.tmpl
+++ b/pages/signup.tmpl
@@ -79,17 +79,17 @@ form dd {
 					<label>
 						<dt>Username</dt>
 						<dd>
-							<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" tabindex="1" autofocus />
+							<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" autofocus />
 							{{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
 						</dd>
 					</label>
 					<label>
 						<dt>Password</dt>
-						<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" tabindex="2" style="width: 100%; box-sizing: border-box;" /></dd>
+						<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" style="width: 100%; box-sizing: border-box;" /></dd>
 					</label>
 					<label>
 						<dt>Email (optional)</dt>
-						<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" tabindex="3" /></dd>
+						<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" /></dd>
 					</label>
 					<dt>
 						<button id="btn-create" type="submit" style="margin-top: 0">Create blog</button>

--- a/pages/signup.tmpl
+++ b/pages/signup.tmpl
@@ -76,21 +76,15 @@ form dd {
 			<form action="/auth/signup" method="POST" id="signup-form" onsubmit="return signup()">
 				<input type="hidden" name="invite_code" value="{{.Invite}}" />
 				<dl class="billing">
-					<label>
-						<dt>Username</dt>
-						<dd>
-							<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" autofocus />
-							{{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
-						</dd>
-					</label>
-					<label>
-						<dt>Password</dt>
-						<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" style="width: 100%; box-sizing: border-box;" /></dd>
-					</label>
-					<label>
-						<dt>Email (optional)</dt>
-						<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" /></dd>
-					</label>
+					<dt><label for="alias">Username</label></dt>
+					<dd>
+						<input type="text" id="alias" name="alias" style="width: 100%; box-sizing: border-box;" autofocus />
+						{{if .Federation}}<p id="alias-site" class="demo">@<strong>your-username</strong>@{{.FriendlyHost}}</p>{{else}}<p id="alias-site" class="demo">{{.FriendlyHost}}/<strong>your-username</strong></p>{{end}}
+					</dd>
+					<dt><label for="password">Password</label></dt>
+					<dd><input type="password" id="password" name="pass" autocomplete="new-password" placeholder="" style="width: 100%; box-sizing: border-box;" /></dd>
+					<dt><label for="email">Email (optional)</label></dt>
+					<dd><input type="email" name="email" id="email" style="letter-spacing: 1px; width: 100%; box-sizing: border-box;" placeholder="me@example.com" /></dd>
 					<dt>
 						<button id="btn-create" type="submit" style="margin-top: 0">Create blog</button>
 					</dt>

--- a/templates/password-collection.tmpl
+++ b/templates/password-collection.tmpl
@@ -52,7 +52,7 @@
 					{{end}}
 					<input type="hidden" name="alias" value="{{.Alias}}" />
 					<input type="hidden" name="to" value="{{.Next}}" />
-					<input type="password" autocomplete="new-password" name="password" tabindex="1" autofocus />
+					<input type="password" autocomplete="new-password" name="password" autofocus />
 					<p><input type="submit" value="Enter" /></p>
 				</form>
 			</div>

--- a/templates/user/settings.tmpl
+++ b/templates/user/settings.tmpl
@@ -42,7 +42,7 @@ h3 { font-weight: normal; }
 		<div class="option">
 			<h3>Username</h3>
 			<div class="section">
-				<input type="text" name="username" value="{{.Username}}" tabindex="1" />
+				<input type="text" name="username" value="{{.Username}}" />
 				<input type="submit" value="Update" style="margin-left: 1em;" />
 			</div>
 		</div>
@@ -57,11 +57,11 @@ h3 { font-weight: normal; }
 			<div class="section">
 				{{if and (not .HasPass) (not .IsLogOut)}}<div class="alert info"><p>Add a passphrase to easily log in to your account.</p></div>{{end}}
 				{{if .HasPass}}<p>Current passphrase</p>
-				<input type="password" name="current-pass" placeholder="Current passphrase" tabindex="1" /> <input class="show" type="checkbox" id="show-cur-pass" /><label for="show-cur-pass"> Show</label>
+				<input type="password" name="current-pass" placeholder="Current passphrase" /> <input class="show" type="checkbox" id="show-cur-pass" /><label for="show-cur-pass"> Show</label>
 				<p>New passphrase</p>
 				{{end}}
 				{{if .IsLogOut}}<input type="text" value="{{.Username}}" style="display:none" />{{end}}
-				<input type="password" name="new-pass" autocomplete="new-password" placeholder="New passphrase" tabindex="{{if .IsLogOut}}1{{else}}2{{end}}" /> <input class="show" type="checkbox" id="show-new-pass" /><label for="show-new-pass"> Show</label>
+				<input type="password" name="new-pass" autocomplete="new-password" placeholder="New passphrase" /> <input class="show" type="checkbox" id="show-new-pass" /><label for="show-new-pass"> Show</label>
 			</div>
 		</div>
 
@@ -73,12 +73,12 @@ h3 { font-weight: normal; }
 					<li>No-passphrase login</li>
 					<li>Account recovery if you forget your passphrase</li>
 				</ul></div>{{end}}
-				<input type="email" name="email" style="letter-spacing: 1px" placeholder="Email address" value="{{.Email}}" size="40" tabindex="{{if .IsLogOut}}2{{else}}3{{end}}" />
+				<input type="email" name="email" style="letter-spacing: 1px" placeholder="Email address" value="{{.Email}}" size="40" />
 			</div>
 		</div>
 
 		<div class="option" style="text-align: center;">
-			<input type="submit" value="Save changes" tabindex="4" />
+			<input type="submit" value="Save changes" />
 		</div>
 	</form>
 	{{end}}


### PR DESCRIPTION
This PR fixes a couple of accessibility issues reported by Web Vitals. 

**Some elements have a [tabindex] value greater than 0**

> Although technically valid, using a tabindex greater than 0 is considered an anti-pattern because it shifts the affected element to the end of the tab order. This unexpected behavior can make it seem like some elements can't be accessed via keyboard, which is frustrating for users who rely on assistive technologies.

**<dl>s do not contain only properly ordered <dt> and <dd> groups, <script>, or <template> elements** and **Definition list items are not wrapped in <dl> elements**

> Screen readers and other assistive technologies have a specific way of announcing definition lists. When definition lists are not properly marked up, assistive technologies may produce confusing or inaccurate output.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
