### PR TITLE
Elide Markdown when generating slug

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -1247,6 +1247,8 @@ func getSlug(title, lang string) string {
 
 func getSlugFromPost(title, body, lang string) string {
 	if title == "" {
+		// Remove Markdown, so e.g. link URLs and image alt text don't make it into the slug
+		body = strings.TrimSpace(stripmd.StripOptions(body, stripmd.Options{SkipImages: true}))
 		title = postTitle(body, body)
 	}
 	title = parse.PostLede(title, false)


### PR DESCRIPTION
This makes sure e.g. link URLs and image alt text don't get included in the slug.

Closes [T329](https://phabricator.write.as/T329)

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
