### PR TITLE
Update 404 error message

### DIFF
--- a/pages/404-general.tmpl
+++ b/pages/404-general.tmpl
@@ -1,7 +1,6 @@
 {{define "head"}}<title>Page not found &mdash; {{.SiteName}}</title>{{end}}
 {{define "content"}}
 		<div class="error-page">
-			<p class="msg">This page is missing.</p>
-			<p>Are you sure it was ever here?</p>
+			<p class="msg">Page not found.</p>
 		</div>
 {{end}}


### PR DESCRIPTION
This is a small pull request to replace the current 404 error message. The current one implies that the error is the person visiting the site's fault, which is interpreted by some, especially in translation, as relatively hostile. This simplified, message makes it clear that the error is in software, and not the fault of a person.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
