### PR TITLE
Database name changed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   db:
     image: "mariadb:latest"
     volumes:
-      - db-data:/var/lib/mysql/data
+      - db-data:/var/lib/mysql/writefreely
     networks:
       - writefreely
     environment:


### PR DESCRIPTION
From my testing, the database name in the docker image changed from 
data => writefreely.
This PR fixes that issue.


- [x] I have signed the [CLA](https://phabricator.write.as/L1)
