### PR TITLE
Show post excerpt in stats list when no post title

### DIFF
--- a/database.go
+++ b/database.go
@@ -1774,7 +1774,7 @@ func (db *datastore) GetTopPosts(u *User, alias string, hostName string) (*[]Pub
 		where = " AND alias = ?"
 		params = append(params, alias)
 	}
-	rows, err := db.Query("SELECT p.id, p.slug, p.view_count, p.title, c.alias, c.title, c.description, c.view_count FROM posts p LEFT JOIN collections c ON p.collection_id = c.id WHERE p.owner_id = ?"+where+" ORDER BY p.view_count DESC, created DESC LIMIT 25", params...)
+	rows, err := db.Query("SELECT p.id, p.slug, p.view_count, p.title, p.content, c.alias, c.title, c.description, c.view_count FROM posts p LEFT JOIN collections c ON p.collection_id = c.id WHERE p.owner_id = ?"+where+" ORDER BY p.view_count DESC, created DESC LIMIT 25", params...)
 	if err != nil {
 		log.Error("Failed selecting from posts: %v", err)
 		return nil, impart.HTTPError{http.StatusInternalServerError, "Couldn't retrieve user top posts."}
@@ -1788,7 +1788,7 @@ func (db *datastore) GetTopPosts(u *User, alias string, hostName string) (*[]Pub
 		c := Collection{}
 		var alias, title, description sql.NullString
 		var views sql.NullInt64
-		err = rows.Scan(&p.ID, &p.Slug, &p.ViewCount, &p.Title, &alias, &title, &description, &views)
+		err = rows.Scan(&p.ID, &p.Slug, &p.ViewCount, &p.Title, &p.Content, &alias, &title, &description, &views)
 		if err != nil {
 			log.Error("Failed scanning User.getPosts() row: %v", err)
 			gotErr = true

--- a/templates/user/stats.tmpl
+++ b/templates/user/stats.tmpl
@@ -51,7 +51,7 @@ td.none {
 			<th class="num">Total Views</th>
 		</tr>
 		{{range .TopPosts}}<tr>
-			<td style="word-break: break-all;"><a href="{{if .Collection}}{{.Collection.CanonicalURL}}{{.Slug.String}}{{else}}/{{.ID}}{{end}}">{{if ne .Title.String ""}}{{.Title.String}}{{else}}<em>{{.ID}}</em>{{end}}</a></td>
+			<td style="word-break: break-all;"><a href="{{if .Collection}}{{.Collection.CanonicalURL}}{{.Slug.String}}{{else}}/{{.ID}}{{end}}">{{if ne .DisplayTitle ""}}{{.DisplayTitle}}{{else}}<em>{{.ID}}</em>{{end}}</a></td>
 			{{ if not $.Collection }}<td>{{if .Collection}}<a href="{{.Collection.CanonicalURL}}">{{.Collection.Title}}</a>{{else}}<em>Draft</em>{{end}}</td>{{ end }}
 			<td class="num">{{.ViewCount}}</td>
 		</tr>{{end}}


### PR DESCRIPTION
Uses a post's excerpt instead of its ID in the "Top Posts" stats list when the post doesn't have an explicit title.

Originally requested [on the forum](https://discuss.write.as/t/use-non-random-ids-for-untitled-posts-in-blog-stats/5046).

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
