### PR TITLE
Add unix socket support

### DIFF
--- a/app.go
+++ b/app.go
@@ -504,9 +504,8 @@ requests. We recommend supplying a valid host name.`)
 			err = http.ListenAndServeTLS(fmt.Sprintf("%s:443", bindAddress), app.cfg.Server.TLSCertPath, app.cfg.Server.TLSKeyPath, r)
 		}
 	} else {
-		var network string
-		var protocol string
-
+		network := "tcp"
+		protocol := "http"
 		if strings.HasPrefix(bindAddress, "/") {
 			network = "unix"
 			protocol = "http+unix"
@@ -519,8 +518,6 @@ requests. We recommend supplying a valid host name.`)
 				os.Exit(1)
 			}
 		} else {
-			network = "tcp"
-			protocol = "http"
 			bindAddress = fmt.Sprintf("%s:%d", bindAddress, app.cfg.Server.Port)
 		}
 

--- a/app.go
+++ b/app.go
@@ -845,6 +845,16 @@ func connectToDatabase(app *App) {
 func shutdown(app *App) {
 	log.Info("Closing database connection...")
 	app.db.Close()
+	if strings.HasPrefix(app.cfg.Server.Bind, "/") {
+		// Clean up socket
+		log.Info("Removing socket file...")
+		err := os.Remove(app.cfg.Server.Bind)
+		if err != nil {
+			log.Error("Unable to remove socket: %s", err)
+			os.Exit(1)
+		}
+		log.Info("Success.")
+	}
 }
 
 // CreateUser creates a new admin or normal user from the given credentials.

--- a/app.go
+++ b/app.go
@@ -513,9 +513,9 @@ requests. We recommend supplying a valid host name.`)
 
 			// old sockets will remain after server closes;
 			// we need to delete them in order to open new ones
-			removeSocketErr := os.Remove(bindAddress)
-			if removeSocketErr != nil && !os.IsNotExist(removeSocketErr) {
-				log.Error("%s already exists but could not be removed: %v", bindAddress, removeSocketErr)
+			err = os.Remove(bindAddress)
+			if err != nil && !os.IsNotExist(err) {
+				log.Error("%s already exists but could not be removed: %v", bindAddress, err)
 				os.Exit(1)
 			}
 		} else {
@@ -526,16 +526,16 @@ requests. We recommend supplying a valid host name.`)
 
 		log.Info("Serving on %s://%s", protocol, bindAddress)
 		log.Info("---")
-		listener, listenErr := net.Listen(network, bindAddress)
-		if listenErr != nil {
-			log.Error("Could not bind to address: %v", listenErr)
+		listener, err := net.Listen(network, bindAddress)
+		if err != nil {
+			log.Error("Could not bind to address: %v", err)
 			os.Exit(1)
 		}
 
 		if network == "unix" {
-			chmodSocketErr := os.Chmod(bindAddress, 0o666)
-			if chmodSocketErr != nil {
-				log.Error("Could not update socket permissions: %v", chmodSocketErr)
+			err = os.Chmod(bindAddress, 0o666)
+			if err != nil {
+				log.Error("Could not update socket permissions: %v", err)
 				os.Exit(1)
 			}
 		}


### PR DESCRIPTION
Enables listening on unix sockets by specifying a file path for the bind address. Fixes #542.

- [x] I have signed the [CLA](https://phabricator.write.as/L1)