### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.go]
+indent_style = tab


### PR DESCRIPTION
This helps ensure that editors will follow the format expected by `go fmt` by default.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
