### PR TITLE
Truncate Post created times down to 1 second

### DIFF
--- a/database.go
+++ b/database.go
@@ -656,7 +656,7 @@ func (db *datastore) CreatePost(userID, collID int64, post *SubmittedPost) (*Pos
 		}
 	}
 
-	created := time.Now()
+	created := time.Now().Truncate(time.Second)
 	if db.driverName == driverSQLite {
 		// SQLite stores datetimes in UTC, so convert time.Now() to it here
 		created = created.UTC()
@@ -665,7 +665,7 @@ func (db *datastore) CreatePost(userID, collID int64, post *SubmittedPost) (*Pos
 		created, err = time.Parse("2006-01-02T15:04:05Z", *post.Created)
 		if err != nil {
 			log.Error("Unable to parse Created time '%s': %v", *post.Created, err)
-			created = time.Now()
+			created = time.Now().Truncate(time.Second)
 			if db.driverName == driverSQLite {
 				// SQLite stores datetimes in UTC, so convert time.Now() to it here
 				created = created.UTC()

--- a/migrations/v11.go
+++ b/migrations/v11.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2020 A Bunch Tell LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package migrations
+
+func supportPostSignatures(db *datastore) error {
+	t, err := db.Begin()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	_, err = t.Exec(`UPDATE posts SET created = DATETIME(created)`)
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	err = t.Commit()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This fixes an issue with the writefreely ios application.

Swift is unable to parse date-times with fractions of a second included.

This has 2 changes.

1. On all now posts created, we truncate time-created down to the second
2. A migration script to update the 'created' column to strip out the milliseconds.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
