### PR TITLE
Widen oauth_users.access_token to prevent insertion failure

### DIFF
--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -66,6 +66,7 @@ var migrations = []Migration{
 	New("support oauth via invite", oauthInvites),                   // V7 -> V8 (v0.12.0)
 	New("optimize drafts retrieval", optimizeDrafts),                // V8 -> V9
 	New("support post signatures", supportPostSignatures),           // V9 -> V10
+	New("Widen oauth_users.access_token", widenOauthAcceesToken),    // V10 -> V11
 }
 
 // CurrentVer returns the current migration version the application is on

--- a/migrations/v11.go
+++ b/migrations/v11.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package migrations
+
+/**
+ * Widen `oauth_users.access_token`, necessary only for mysql
+ */
+func widenOauthAcceesToken(db *datastore) error {
+	if db.driverName == driverMySQL {
+		t, err := db.Begin()
+		if err != nil {
+			t.Rollback()
+			return err
+		}
+
+		_, err = t.Exec(`ALTER TABLE oauth_users MODIFY COLUMN access_token ` + db.typeText() + db.collateMultiByte() + ` NULL`)
+		if err != nil {
+			t.Rollback()
+			return err
+		}
+
+		err = t.Commit()
+		if err != nil {
+			t.Rollback()
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Hi,

I configured an instance using mariadb and [Keycloak](https://www.keycloak.org/) for SSO.
User creation was failing since the returned access token is longer than the current field in db (`VARCHAR(512)`)

I believe switching to `TEXT` is better than setting an arbitrary length, overhead should be minimal especially since I don't believe it's in any index.

I added a conditional to  run it only on `MySQL` since I believe `SqlLite` only use `TEXT`.
    
---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
