### PR TITLE
Additionnal config for oauth registration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -76,47 +76,51 @@ type (
 	}
 
 	GitlabOauthCfg struct {
-		ClientID         string `ini:"client_id"`
-		ClientSecret     string `ini:"client_secret"`
-		Host             string `ini:"host"`
-		DisplayName      string `ini:"display_name"`
-		CallbackProxy    string `ini:"callback_proxy"`
-		CallbackProxyAPI string `ini:"callback_proxy_api"`
+		ClientID            string `ini:"client_id"`
+		ClientSecret        string `ini:"client_secret"`
+		Host                string `ini:"host"`
+		DisplayName         string `ini:"display_name"`
+		CallbackProxy       string `ini:"callback_proxy"`
+		CallbackProxyAPI    string `ini:"callback_proxy_api"`
+		AllowRegistration   bool   `ini:"allow_registration"`
 	}
 
 	GiteaOauthCfg struct {
-		ClientID         string `ini:"client_id"`
-		ClientSecret     string `ini:"client_secret"`
-		Host             string `ini:"host"`
-		DisplayName      string `ini:"display_name"`
-		CallbackProxy    string `ini:"callback_proxy"`
-		CallbackProxyAPI string `ini:"callback_proxy_api"`
+		ClientID            string `ini:"client_id"`
+		ClientSecret        string `ini:"client_secret"`
+		Host                string `ini:"host"`
+		DisplayName         string `ini:"display_name"`
+		CallbackProxy       string `ini:"callback_proxy"`
+		CallbackProxyAPI    string `ini:"callback_proxy_api"`
+		AllowRegistration   bool   `ini:"allow_registration"`
 	}
 
 	SlackOauthCfg struct {
-		ClientID         string `ini:"client_id"`
-		ClientSecret     string `ini:"client_secret"`
-		TeamID           string `ini:"team_id"`
-		CallbackProxy    string `ini:"callback_proxy"`
-		CallbackProxyAPI string `ini:"callback_proxy_api"`
+		ClientID            string `ini:"client_id"`
+		ClientSecret        string `ini:"client_secret"`
+		TeamID              string `ini:"team_id"`
+		CallbackProxy       string `ini:"callback_proxy"`
+		CallbackProxyAPI    string `ini:"callback_proxy_api"`
+		AllowRegistration   bool   `ini:"allow_registration"`
 	}
 
 	GenericOauthCfg struct {
-		ClientID         string `ini:"client_id"`
-		ClientSecret     string `ini:"client_secret"`
-		Host             string `ini:"host"`
-		DisplayName      string `ini:"display_name"`
-		CallbackProxy    string `ini:"callback_proxy"`
-		CallbackProxyAPI string `ini:"callback_proxy_api"`
-		TokenEndpoint    string `ini:"token_endpoint"`
-		InspectEndpoint  string `ini:"inspect_endpoint"`
-		AuthEndpoint     string `ini:"auth_endpoint"`
-		Scope            string `ini:"scope"`
-		AllowDisconnect  bool   `ini:"allow_disconnect"`
-		MapUserID        string `ini:"map_user_id"`
-		MapUsername      string `ini:"map_username"`
-		MapDisplayName   string `ini:"map_display_name"`
-		MapEmail         string `ini:"map_email"`
+		ClientID            string `ini:"client_id"`
+		ClientSecret        string `ini:"client_secret"`
+		Host                string `ini:"host"`
+		DisplayName         string `ini:"display_name"`
+		CallbackProxy       string `ini:"callback_proxy"`
+		CallbackProxyAPI    string `ini:"callback_proxy_api"`
+		TokenEndpoint       string `ini:"token_endpoint"`
+		InspectEndpoint     string `ini:"inspect_endpoint"`
+		AuthEndpoint        string `ini:"auth_endpoint"`
+		Scope               string `ini:"scope"`
+		AllowDisconnect     bool   `ini:"allow_disconnect"`
+		MapUserID           string `ini:"map_user_id"`
+		MapUsername         string `ini:"map_username"`
+		MapDisplayName      string `ini:"map_display_name"`
+		MapEmail            string `ini:"map_email"`
+		AllowRegistration   bool   `ini:"allow_registration"`
 	}
 
 	// AppCfg holds values that affect how the application functions


### PR DESCRIPTION
Hi,

I configured an instance using [Keycloak](https://www.keycloak.org/) for SSO but I wanted to be able to allow registration after a successful authentication without opening it to everyone or using an invitation code.

When using an external oauth provider I believe it makes sense to be able to control registration independently of the global setting.

Added `allow_registration` to external oauth configs to allow the ability to control this logic.
I omitted it from the `WriteAsOauth` config since I believe it does not make sense, just reused `OpenRegistration` when I needed to set a parameter in  `configureWriteAsOauth`. 
I added the `AllowRegistration` control to the `oauthHandler`  since it makes the change way less verbose than adding an additional function to all the different `oauthClient`.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
