### PR TITLE
Catch and output directory walking errors

### DIFF
--- a/author/author.go
+++ b/author/author.go
@@ -11,6 +11,7 @@
 package author
 
 import (
+	"github.com/writeas/web-core/log"
 	"github.com/writefreely/writefreely/config"
 	"os"
 	"path/filepath"
@@ -113,10 +114,17 @@ func IsValidUsername(cfg *config.Config, username string) bool {
 	// Username is invalid if page with the same name exists. So traverse
 	// available pages, adding them to reservedUsernames map that'll be checked
 	// later.
-	filepath.Walk(filepath.Join(cfg.Server.PagesParentDir, "pages"), func(path string, i os.FileInfo, err error) error {
+	err := filepath.Walk(filepath.Join(cfg.Server.PagesParentDir, "pages"), func(path string, i os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		reservedUsernames[i.Name()] = true
 		return nil
 	})
+	if err != nil {
+		log.Error("[IMPORTANT WARNING]: Could not determine IsValidUsername! %s", err)
+		return false
+	}
 
 	// Username is invalid if it is reserved!
 	if _, reserved := reservedUsernames[username]; reserved {

--- a/templates.go
+++ b/templates.go
@@ -135,7 +135,10 @@ func InitTemplates(cfg *config.Config) error {
 
 	log.Info("Loading pages...")
 	// Initialize all static pages that use the base template
-	filepath.Walk(filepath.Join(cfg.Server.PagesParentDir, pagesDir), func(path string, i os.FileInfo, err error) error {
+	err = filepath.Walk(filepath.Join(cfg.Server.PagesParentDir, pagesDir), func(path string, i os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !i.IsDir() && !strings.HasPrefix(i.Name(), ".") {
 			key := i.Name()
 			initPage(cfg.Server.PagesParentDir, path, key)
@@ -143,10 +146,16 @@ func InitTemplates(cfg *config.Config) error {
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
 	log.Info("Loading user pages...")
 	// Initialize all user pages that use base templates
-	filepath.Walk(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir, "user"), func(path string, f os.FileInfo, err error) error {
+	err = filepath.Walk(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir, "user"), func(path string, f os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if !f.IsDir() && !strings.HasPrefix(f.Name(), ".") {
 			corePath := path
 			if cfg.Server.TemplatesParentDir != "" {
@@ -162,6 +171,9 @@ func InitTemplates(cfg *config.Config) error {
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Previously, app would panic and admins would see unhelpful errors. Now we catch any errors and return them and/or log.

This closes #620

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
