### PR TITLE
Abort startup if run as root

### DIFF
--- a/cmd/writefreely/main.go
+++ b/cmd/writefreely/main.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"syscall"
 
 	"github.com/gorilla/mux"
 	"github.com/urfave/cli/v2"
@@ -22,6 +23,10 @@ import (
 )
 
 func main() {
+	if syscall.Getuid() == 0 {
+		log.Error("Running as root is insecure. Use setcap for privileged resource access")
+		os.Exit(1)
+	}
 	cli.VersionPrinter = func(c *cli.Context) {
 		fmt.Printf("%s\n", c.App.Version)
 	}


### PR DESCRIPTION
## The Problem
Running services permanently as `root` is considered a bad practice, because any vulnerability in the service immediately poses the threat of full system takeover.

The [installation instructions](https://writefreely.org/start) for Writefreely tell users to setup services (e.g., via systemd) that run as root. This fact has been reported and criticised here before (#85), but unfortunately without any consequences.

## The Solution
This patch prevents Writefreely from being run as root. It simply aborts with an error if you try to do so.

## Notes
To accompany this patch, the installation instructions should be changed to use non-root service UIDs/GIDs.
I'd be happy to provide pull requests for that as well, but this part of the documentation seems out of scope of the documentation repo.

For standalone operation of writefreely, the best practice to allocate privileged ports like (80/443) would be to use `setcap` on Linux systems. Alternatively, writefreely could consider dropping privileges after their allocation.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
