### PR TITLE
Strip debugging information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GITREV=`git describe | cut -c 2-`
-LDFLAGS=-ldflags="-X 'github.com/writefreely/writefreely.softwareVer=$(GITREV)'"
+LDFLAGS=-ldflags="-s -w -X 'github.com/writefreely/writefreely.softwareVer=$(GITREV)'"
 
 GOCMD=go
 GOINSTALL=$(GOCMD) install $(LDFLAGS)


### PR DESCRIPTION
Using `go build -ldflags="-s -w"` reduces the file size of the binary by about 11 MB (from 39 MB to 28 MB).

---

- [X] I have signed the [CLA](https://phabricator.write.as/L1)
