### PR TITLE
Loosen restrictions on rendered img alt attribute

### DIFF
--- a/postrender.go
+++ b/postrender.go
@@ -270,6 +270,7 @@ func getSanitizationPolicy() *bluemonday.Policy {
 	policy.AllowAttrs("target").OnElements("a")
 	policy.AllowAttrs("title").OnElements("abbr")
 	policy.AllowAttrs("style", "class", "id").Globally()
+	policy.AllowAttrs("alt").OnElements("img")
 	policy.AllowElements("header", "footer")
 	policy.AllowURLSchemes("http", "https", "mailto", "xmpp")
 	return policy
@@ -284,12 +285,13 @@ func sanitizePost(content string) string {
 // choosing what to generate. In case a post has a title, this function will
 // fail, and logic should instead be implemented to skip this when there's no
 // title, like so:
-//    var desc string
-//    if title == "" {
-//        desc = postDescription(content, title, friendlyId)
-//    } else {
-//        desc = shortPostDescription(content)
-//    }
+//
+//	var desc string
+//	if title == "" {
+//	    desc = postDescription(content, title, friendlyId)
+//	} else {
+//	    desc = shortPostDescription(content)
+//	}
 func postDescription(content, title, friendlyId string) string {
 	maxLen := 140
 


### PR DESCRIPTION
Previously, certain characters weren't allowed, and they would cause the entire alt attribute to be elided from the rendered page. Since we safely sanitize the content of this attribute anyway, this is unnecessary, so we now allow all text entered there.

Fixes #649

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
