### PR TITLE
Fix compatibility issues with MySQL 8.0.4+ regex

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type (
 		Host     string `ini:"host"`
 		Port     int    `ini:"port"`
 		TLS      bool   `ini:"tls"`
+		IcuRegex bool   `ini:"icu_regex"`
 	}
 
 	WriteAsOauthCfg struct {

--- a/config/setup.go
+++ b/config/setup.go
@@ -12,12 +12,13 @@ package config
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/mitchellh/go-wordwrap"
 	"github.com/writeas/web-core/auth"
-	"strconv"
-	"strings"
 )
 
 type SetupData struct {
@@ -227,6 +228,17 @@ func Configure(fname string, configSections string) (*SetupData, error) {
 				return data, err
 			}
 			data.Config.Database.Port, _ = strconv.Atoi(dbPort) // Ignore error, as we've already validated number
+
+			selPrompt = promptui.Select{
+				Templates: selTmpls,
+				Label:     "Are you using MySQL 8.0.4 or higher?",
+				Items:     []string{"Yes", "No"},
+			}
+			_, icuRegex, err := selPrompt.Run()
+			if err != nil {
+				return data, err
+			}
+			data.Config.Database.IcuRegex = icuRegex == "Yes"
 		} else if sel == 1 {
 			// Configure for SQLite
 			data.Config.UseSQLite(isNewCfg)

--- a/database.go
+++ b/database.go
@@ -14,11 +14,12 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/writeas/web-core/silobridge"
-	wf_db "github.com/writefreely/writefreely/db"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/writeas/web-core/silobridge"
+	wf_db "github.com/writefreely/writefreely/db"
 
 	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
@@ -1229,7 +1230,16 @@ func (db *datastore) GetPostsTagged(cfg *config.Config, c *Collection, tag strin
 	if db.driverName == driverSQLite {
 		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) regexp ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, `.*#`+strings.ToLower(tag)+`\b.*`)
 	} else {
-		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) RLIKE ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, "#"+strings.ToLower(tag)+"[[:>:]]")
+		// MySQL versions prior to 8.0.4 used Henry Spencer's implementation of regular expressions
+		// which is not compatible with newer - International Components for Unicode (ICU) regular expressions.
+		var regexSuffix string
+		if cfg.Database.IcuRegex {
+			regexSuffix = "\\b"
+		} else {
+			regexSuffix = "[[:>:]]"
+		}
+
+		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) RLIKE ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, "#"+strings.ToLower(tag)+regexSuffix)
 	}
 	if err != nil {
 		log.Error("Failed selecting from posts: %v", err)


### PR DESCRIPTION
As per MySQL documentation (https://dev.mysql.com/doc/refman/8.0/en/regexp.html):

>MySQL implements regular expression support using International Components for Unicode (ICU), which provides full Unicode support and is multibyte safe. (Prior to MySQL 8.0.4, MySQL used Henry Spencer's implementation of regular expressions, which operates in byte-wise fashion and is not multibyte safe. For information about ways in which applications that use regular expressions may be affected by the implementation change, see [Regular Expression Compatibility Considerations](https://dev.mysql.com/doc/refman/8.0/en/regexp.html#regexp-compatibility).

In the same document it states:

>The Spencer library supports word-beginning and word-end boundary markers ([[:<:]] and [[:>:]] notation). ICU does not. For ICU, you can use \b to match word boundaries; double the backslash because MySQL interprets it as the escape character within strings.

Fixes: https://github.com/writefreely/writefreely/issues/615
Fixes: https://github.com/writefreely/writefreely/issues/614

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
