### PR TITLE
Allows library users to replace the underlying listener used by the application

### DIFF
--- a/gopher.go
+++ b/gopher.go
@@ -24,10 +24,13 @@ import (
 
 func initGopher(apper Apper) {
 	handler := NewWFHandler(apper)
-
 	gopher.HandleFunc("/", handler.Gopher(handleGopher))
 	log.Info("Serving on gopher://localhost:%d", apper.App().Config().Server.GopherPort)
-	gopher.ListenAndServe(fmt.Sprintf(":%d", apper.App().Config().Server.GopherPort), nil)
+	listener, err := Listen("tcp", fmt.Sprintf("%s:%d", apper.App().Config().Server.Bind, apper.App().Config().Server.GopherPort))
+	if err != nil {
+		panic(err)
+	}
+	gopher.Serve(listener, nil)
 }
 
 // Utility function to strip the URL from the hostname provided by app.cfg.App.Host


### PR DESCRIPTION
This PR alters the writefreely app in such a way that the behavior is identical to before, but, the `Listen` function is called separately from the `Serve` function, and the `Listen` function is declared as a variable at the top scope, who's value is by default `net.Listen`. This allows people who are using writefreely to create a replacement for the `Listen` function which will be called by the app.

Use Cases:

 - Easy selfhosted blogging without port-forwarding hassles/risks or VPS expenses
 - Listening on Tor or I2P services directly, without listening on other interfaces
 - Listening on dweb-type systems such as IPFS
 - Automatic discovery of VPNs such as Tailscale

For instance, this file(in my tree as `i2p.go` but not checked in on this PR) will automatically configure writefreely to listen on I2P, and if it's asked to federate, it will also federate over I2P.

``` Go
package writefreely

import (
	"net"
	"net/http"
	"strings"

	"github.com/eyedeekay/goSam"
	"github.com/eyedeekay/onramp"
)

func ListenUnixI2P(network, addr string) (net.Listener, error) {
	if network == "unix" {
		return net.Listen(network, addr)
	}
	host := strings.Split(addr, ":")[0]
	if host == "localhost" || host == "127.0.0.1" {
		return net.Listen(network, addr)
	}
	garlic, err := onramp.NewGarlic(addr, "127.0.0.1:7656", onramp.OPT_DEFAULTS)
	if err != nil {
		return nil, err
	}
	return garlic.NewListener(network, addr)
}

var sam *goSam.Client

func init() {
	Listen = ListenUnixI2P
	var err error
	sam, err = goSam.NewDefaultClient()
	if err != nil {
		panic(err)
	}
	http.DefaultClient = &http.Client{
		Transport: &http.Transport{
			Dial:        sam.Dial,
			DialContext: sam.DialContext,
		},
	}
}
```

This PR is related to #662 however it does not accomodate "multiple" listeners in the same app.

---

- [ X] I have signed the [CLA](https://phabricator.write.as/L1)
