### PR TITLE
chore: remove refs to deprecated io/ioutil

### DIFF
--- a/account_import.go
+++ b/account_import.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html/template"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -100,7 +99,7 @@ func handleImport(app *App, u *User, w http.ResponseWriter, r *http.Request) err
 			}
 			defer file.Close()
 
-			tempFile, err := ioutil.TempFile("", "post-upload-*.txt")
+			tempFile, err := os.CreateTemp("", "post-upload-*.txt")
 			if err != nil {
 				fileErrs = append(fileErrs, fmt.Errorf("Internal error for %s", formFile.Filename))
 				log.Error("import file: create temp file %s: %v", formFile.Filename, err)

--- a/activitypub.go
+++ b/activitypub.go
@@ -17,7 +17,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -549,7 +549,7 @@ func makeActivityPost(hostName string, p *activitystreams.Person, url string, m 
 		defer resp.Body.Close()
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}
@@ -601,7 +601,7 @@ func resolveIRI(hostName, url string) ([]byte, error) {
 		defer resp.Body.Close()
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/app.go
+++ b/app.go
@@ -16,7 +16,6 @@ import (
 	_ "embed"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -177,7 +176,7 @@ func (app *App) LoadKeys() error {
 		executable = filepath.Base(executable)
 	}
 
-	app.keys.EmailKey, err = ioutil.ReadFile(emailKeyPath)
+	app.keys.EmailKey, err = os.ReadFile(emailKeyPath)
 	if err != nil {
 		return err
 	}
@@ -185,7 +184,7 @@ func (app *App) LoadKeys() error {
 	if debugging {
 		log.Info("  %s", cookieAuthKeyPath)
 	}
-	app.keys.CookieAuthKey, err = ioutil.ReadFile(cookieAuthKeyPath)
+	app.keys.CookieAuthKey, err = os.ReadFile(cookieAuthKeyPath)
 	if err != nil {
 		return err
 	}
@@ -193,7 +192,7 @@ func (app *App) LoadKeys() error {
 	if debugging {
 		log.Info("  %s", cookieKeyPath)
 	}
-	app.keys.CookieKey, err = ioutil.ReadFile(cookieKeyPath)
+	app.keys.CookieKey, err = os.ReadFile(cookieKeyPath)
 	if err != nil {
 		return err
 	}
@@ -201,7 +200,7 @@ func (app *App) LoadKeys() error {
 	if debugging {
 		log.Info("  %s", csrfKeyPath)
 	}
-	app.keys.CSRFKey, err = ioutil.ReadFile(csrfKeyPath)
+	app.keys.CSRFKey, err = os.ReadFile(csrfKeyPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			log.Error(`Missing key: %s.

--- a/keys.go
+++ b/keys.go
@@ -13,7 +13,6 @@ package writefreely
 import (
 	"github.com/writeas/web-core/log"
 	"github.com/writefreely/writefreely/key"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -65,7 +64,7 @@ func generateKey(path string) error {
 		log.Error("FAILED. %s. Run writefreely --gen-keys again.", err)
 		return err
 	}
-	err = ioutil.WriteFile(path, b, 0600)
+	err = os.WriteFile(path, b, 0600)
 	if err != nil {
 		log.Error("FAILED writing file: %s", err)
 		return err

--- a/monetization.go
+++ b/monetization.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -144,7 +144,7 @@ func verifyReceipt(receipt, id string) error {
 		defer resp.Body.Close()
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error("Unable to read %s response body: %s", receiptsHost, err)
 		return err

--- a/oauth.go
+++ b/oauth.go
@@ -15,7 +15,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
@@ -450,7 +449,7 @@ func (r *callbackProxyClient) register(ctx context.Context, state string) error 
 
 func limitedJsonUnmarshal(body io.ReadCloser, n int, thing interface{}) error {
 	lr := io.LimitReader(body, int64(n+1))
-	data, err := ioutil.ReadAll(lr)
+	data, err := io.ReadAll(lr)
 	if err != nil {
 		return err
 	}

--- a/templates.go
+++ b/templates.go
@@ -14,9 +14,8 @@ import (
 	"errors"
 	"html/template"
 	"io"
-	"io/ioutil"
-	"net/http"
 	"os"
+	"net/http"
 	"path/filepath"
 	"strings"
 
@@ -120,7 +119,7 @@ func initUserPage(parentDir, path, key string) {
 // InitTemplates loads all template files from the configured parent dir.
 func InitTemplates(cfg *config.Config) error {
 	log.Info("Loading templates...")
-	tmplFiles, err := ioutil.ReadDir(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir))
+	tmplFiles, err := os.ReadDir(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir))
 	if err != nil {
 		return err
 	}

--- a/updates.go
+++ b/updates.go
@@ -12,7 +12,7 @@ package writefreely
 
 import (
 	"github.com/writeas/web-core/log"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"sync"
@@ -121,7 +121,7 @@ func newVersionCheck() (string, error) {
 	if err == nil && res.StatusCode == http.StatusOK {
 		defer res.Body.Close()
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		if err != nil {
 			return "", err
 		}

--- a/webfinger.go
+++ b/webfinger.go
@@ -12,7 +12,7 @@ package writefreely
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -110,7 +110,7 @@ func RemoteLookup(handle string) string {
 		return ""
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error("Error on webfinger response: %v", err)
 		return ""


### PR DESCRIPTION
["io/ioutil" has been deprecated since Go 1.19: As of Go 1.16]

---

- [ ] I have signed the [CLA](https://phabricator.write.as/L1)
