### PR TITLE
Correctly respond to application/ld+json requests

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -496,8 +496,7 @@ func apiCheckCollectionPermissions(app *App, r *http.Request, c *Collection) (in
 
 // fetchCollection handles the API endpoint for retrieving collection data.
 func fetchCollection(app *App, w http.ResponseWriter, r *http.Request) error {
-	accept := r.Header.Get("Accept")
-	if strings.Contains(accept, "application/activity+json") {
+	if IsActivityPubRequest(r) {
 		return handleFetchCollectionActivities(app, w, r)
 	}
 

--- a/posts.go
+++ b/posts.go
@@ -1119,8 +1119,7 @@ func fetchPost(app *App, w http.ResponseWriter, r *http.Request) error {
 
 	p.extractData()
 
-	accept := r.Header.Get("Accept")
-	if strings.Contains(accept, "application/activity+json") {
+	if IsActivityPubRequest(r) {
 		if coll == nil {
 			// This is a draft post; 404 for now
 			// TODO: return ActivityObject

--- a/request.go
+++ b/request.go
@@ -13,10 +13,17 @@ package writefreely
 import (
 	"mime"
 	"net/http"
+	"strings"
 )
 
 func IsJSON(r *http.Request) bool {
 	ct, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	accept := r.Header.Get("Accept")
 	return ct == "application/json" || accept == "application/json"
+}
+
+func IsActivityPubRequest(r *http.Request) bool {
+	accept := r.Header.Get("Accept")
+	return strings.Contains(accept, "application/activity+json") ||
+		accept == "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\""
 }


### PR DESCRIPTION
This returns ActivityStreams objects when the Accept header is `application/ld+json; profile="https://www.w3.org/ns/activitystreams"`, per the ActivityPub spec.

Fixes #564

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
