### PR TITLE
Instruct users to contact admin, not WF developers on 500 page

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -13,6 +13,7 @@ package writefreely
 import (
 	"database/sql"
 	"fmt"
+	"html/template"
 	"net/http"
 	"runtime"
 	"strconv"
@@ -102,13 +103,16 @@ func NewAdminPage(app *App) *AdminPage {
 	return ap
 }
 
-func (c instanceContent) UpdatedFriendly() string {
+func (c instanceContent) UpdatedFriendly() template.HTML {
 	/*
 		// TODO: accept a locale in this method and use that for the format
 		var loc monday.Locale = monday.LocaleEnUS
 		return monday.Format(u.Created, monday.DateTimeFormatsByLocale[loc], loc)
 	*/
-	return c.Updated.Format("January 2, 2006, 3:04 PM")
+	if c.Updated.IsZero() {
+		return "<em>Never</em>"
+	}
+	return template.HTML(c.Updated.Format("January 2, 2006, 3:04 PM"))
 }
 
 func handleViewAdminDash(app *App, u *User, w http.ResponseWriter, r *http.Request) error {
@@ -426,15 +430,20 @@ func handleViewAdminPages(app *App, u *User, w http.ResponseWriter, r *http.Requ
 	}
 
 	// Add in default pages
-	var hasAbout, hasPrivacy bool
+	var hasAbout, hasContact, hasPrivacy bool
 	for i, c := range p.Pages {
-		if hasAbout && hasPrivacy {
+		if hasAbout && hasContact && hasPrivacy {
 			break
 		}
 		if c.ID == "about" {
 			hasAbout = true
 			if !c.Title.Valid {
 				p.Pages[i].Title = defaultAboutTitle(app.cfg)
+			}
+		} else if c.ID == "contact" {
+			hasContact = true
+			if !c.Title.Valid {
+				p.Pages[i].Title = defaultContactTitle()
 			}
 		} else if c.ID == "privacy" {
 			hasPrivacy = true
@@ -449,6 +458,13 @@ func handleViewAdminPages(app *App, u *User, w http.ResponseWriter, r *http.Requ
 			Title:   defaultAboutTitle(app.cfg),
 			Content: defaultAboutPage(app.cfg),
 			Updated: defaultPageUpdatedTime,
+		})
+	}
+	if !hasAbout {
+		p.Pages = append(p.Pages, &instanceContent{
+			ID:      "contact",
+			Title:   defaultContactTitle(),
+			Content: defaultContactPage(app),
 		})
 	}
 	if !hasPrivacy {
@@ -489,6 +505,8 @@ func handleViewAdminPage(app *App, u *User, w http.ResponseWriter, r *http.Reque
 	// Get pre-defined pages, or select slug
 	if slug == "about" {
 		p.Content, err = getAboutPage(app)
+	} else if slug == "contact" {
+		p.Content, err = getContactPage(app)
 	} else if slug == "privacy" {
 		p.Content, err = getPrivacyPage(app)
 	} else if slug == "landing" {
@@ -523,7 +541,7 @@ func handleAdminUpdateSite(app *App, u *User, w http.ResponseWriter, r *http.Req
 	id := vars["page"]
 
 	// Validate
-	if id != "about" && id != "privacy" && id != "landing" && id != "reader" {
+	if id != "about" && id != "contact" && id != "privacy" && id != "landing" && id != "reader" {
 		return impart.HTTPError{http.StatusNotFound, "No such page."}
 	}
 

--- a/admin.go
+++ b/admin.go
@@ -460,7 +460,7 @@ func handleViewAdminPages(app *App, u *User, w http.ResponseWriter, r *http.Requ
 			Updated: defaultPageUpdatedTime,
 		})
 	}
-	if !hasAbout {
+	if !hasContact {
 		p.Pages = append(p.Pages, &instanceContent{
 			ID:      "contact",
 			Title:   defaultContactTitle(),

--- a/app.go
+++ b/app.go
@@ -318,7 +318,7 @@ func handleTemplatedPage(app *App, w http.ResponseWriter, r *http.Request, t *te
 	}{
 		StaticPage: pageForReq(app, r),
 	}
-	if r.URL.Path == "/about" || r.URL.Path == "/privacy" {
+	if r.URL.Path == "/about" || r.URL.Path == "/contact" || r.URL.Path == "/privacy" {
 		var c *instanceContent
 		var err error
 
@@ -329,6 +329,12 @@ func handleTemplatedPage(app *App, w http.ResponseWriter, r *http.Request, t *te
 			p.AboutStats = &InstanceStats{}
 			p.AboutStats.NumPosts, _ = app.db.GetTotalPosts()
 			p.AboutStats.NumBlogs, _ = app.db.GetTotalCollections()
+		} else if r.URL.Path == "/contact" {
+			c, err = getContactPage(app)
+			if c.Updated.IsZero() {
+				// Page was never set up, so return 404
+				return ErrPostNotFound
+			}
 		} else {
 			c, err = getPrivacyPage(app)
 		}

--- a/pages.go
+++ b/pages.go
@@ -40,6 +40,28 @@ func defaultAboutTitle(cfg *config.Config) sql.NullString {
 	return sql.NullString{String: "About " + cfg.App.SiteName, Valid: true}
 }
 
+func getContactPage(app *App) (*instanceContent, error) {
+	c, err := app.db.GetDynamicContent("contact")
+	if err != nil {
+		return nil, err
+	}
+	if c == nil {
+		c = &instanceContent{
+			ID:      "contact",
+			Type:    "page",
+			Content: defaultContactPage(app),
+		}
+	}
+	if !c.Title.Valid {
+		c.Title = defaultContactTitle()
+	}
+	return c, nil
+}
+
+func defaultContactTitle() sql.NullString {
+	return sql.NullString{String: "Contact Us", Valid: true}
+}
+
 func getPrivacyPage(app *App) (*instanceContent, error) {
 	c, err := app.db.GetDynamicContent("privacy")
 	if err != nil {
@@ -68,6 +90,18 @@ func defaultAboutPage(cfg *config.Config) string {
 		return `_` + cfg.App.SiteName + `_ is an interconnected place for you to write and publish, powered by [WriteFreely](https://writefreely.org) and ActivityPub.`
 	}
 	return `_` + cfg.App.SiteName + `_ is a place for you to write and publish, powered by [WriteFreely](https://writefreely.org).`
+}
+
+func defaultContactPage(app *App) string {
+	c, err := app.db.GetCollectionByID(1)
+	if err != nil {
+		return ""
+	}
+	return `_` + app.cfg.App.SiteName + `_ is administered by: [**` + c.Alias + `**](/` + c.Alias + `/).
+
+Contact them at this email address: _EMAIL GOES HERE_.
+
+You can also reach them here...`
 }
 
 func defaultPrivacyPolicy(cfg *config.Config) string {

--- a/pages/500.tmpl
+++ b/pages/500.tmpl
@@ -2,9 +2,7 @@
 {{define "content"}}
 		<div class="content-container tight">
 			<h1>Server error &#x1F635;</h1>
-			<p>Please <a href="https://github.com/writefreely/writefreely/issues/new">contact the human authors</a> of this software and remind them of their many shortcomings.</p>
-			<p>Be gentle, though. They are fragile mortal beings.</p>
-			<p style="margin-top:2em">Also, unlike the AI that will soon replace them, you will need to include an error log from the server in your report. (Utterly <em>primitive</em>, we know.)</p>
+			<p>There seems to be an issue with this server. Please contact the admin and let them know they'll need to fix it.</p>
 			<p>&ndash; {{.SiteName}} &#x1F916;</p>
 		</div>
 {{end}}

--- a/pages/500.tmpl
+++ b/pages/500.tmpl
@@ -2,7 +2,7 @@
 {{define "content"}}
 		<div class="content-container tight">
 			<h1>Server error &#x1F635;</h1>
-			<p>There seems to be an issue with this server. Please contact the admin and let them know they'll need to fix it.</p>
+			<p>There seems to be an issue with this server. Please <a href="/contact">contact the admin</a> and let them know they'll need to fix it.</p>
 			<p>&ndash; {{.SiteName}} &#x1F916;</p>
 		</div>
 {{end}}

--- a/pages/contact.tmpl
+++ b/pages/contact.tmpl
@@ -1,0 +1,8 @@
+{{define "head"}}<title>{{.ContentTitle}} &mdash; {{.SiteName}}</title>
+<meta name="description" content="{{.PlainContent}}">
+{{end}}
+{{define "content"}}<div class="content-container snug">
+	<h1>{{.ContentTitle}}</h1>
+		{{.Content}}
+	</div>
+{{end}}

--- a/templates/user/admin/view-page.tmpl
+++ b/templates/user/admin/view-page.tmpl
@@ -29,6 +29,8 @@ input[type=text] {
 
 	{{if eq .Content.ID "about"}}
 	<p class="page-desc content-desc">Describe what your instance is <a href="/about" target="page">about</a>.</p>
+	{{else if eq .Content.ID "contact"}}
+	<p class="page-desc content-desc">Tell your users and outside visitors how to <a href="/contact" target="page">contact</a> you.</p>
 	{{else if eq .Content.ID "privacy"}}
 	<p class="page-desc content-desc">Outline your <a href="/privacy" target="page">privacy policy</a>.</p>
 	{{else if eq .Content.ID "reader"}}


### PR DESCRIPTION
Misconfigured or broken servers have directed people to the wrong place in the past. This fixes that with a simpler 500 error page directing visitors to a Contact page.

This also adds the ability to customize an instance-wide Contact (`/contact`) page. It provides some boilerplate text that admins might use to describe who runs the instance -- but unlike other dynamic pages, it **won't** publicly show up until the admin has personally customized the page.

**Action required**: all admins of multi-user instances should go to `https://YOUR-INSTANCE/admin/page/contact` and explain the best way for users and visitors to contact them.

Fixes #684

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
