### PR TITLE
Add index to improve post retrieval speed on large instances

### DIFF
--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -70,6 +70,7 @@ var migrations = []Migration{
 	New("support verifying fedi profile", fediverseVerifyProfile),   // V11 -> V12 (v0.14.0)
 	New("support newsletters", supportLetters),                      // V12 -> V13
 	New("support password resetting", supportPassReset),             // V13 -> V14
+	New("speed up blog post retrieval", addPostRetrievalIndex),      // V14 -> V15
 }
 
 // CurrentVer returns the current migration version the application is on

--- a/migrations/v15.go
+++ b/migrations/v15.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2023 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package migrations
+
+func addPostRetrievalIndex(db *datastore) error {
+	t, err := db.Begin()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	_, err = t.Exec("CREATE INDEX posts_get_collection_index ON posts (`collection_id`, `pinned_position`, `created`)")
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	err = t.Commit()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
On an instance with millions of posts across all users, a single blog with thousands of posts on it can take a long time to render. This adds an index to the `posts` table to speed up the basic GetPosts query.

Run: `writefreely db migrate`

Closes #741

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
