### PR TITLE
Correctly respond to application/ld+json requests, part 2

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -853,7 +853,7 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 	}
 
 	// Serve ActivityStreams data now, if requested
-	if strings.Contains(r.Header.Get("Accept"), "application/activity+json") {
+	if IsActivityPubRequest(r) {
 		ac := c.PersonObject()
 		ac.Context = []interface{}{activitystreams.Namespace}
 		setCacheControl(w, apCacheTime)

--- a/handle.go
+++ b/handle.go
@@ -818,7 +818,7 @@ func (h *Handler) handleHTTPError(w http.ResponseWriter, r *http.Request, err er
 			return
 		} else if err.Status == http.StatusNotFound {
 			w.WriteHeader(err.Status)
-			if strings.Contains(r.Header.Get("Accept"), "application/activity+json") {
+			if IsActivityPubRequest(r) {
 				// This is a fediverse request; simply return the header
 				return
 			}

--- a/posts.go
+++ b/posts.go
@@ -1520,7 +1520,7 @@ Are you sure it was ever here?`,
 			fmt.Fprintf(w, "# %s\n\n", p.Title.String)
 		}
 		fmt.Fprint(w, p.Content)
-	} else if strings.Contains(r.Header.Get("Accept"), "application/activity+json") {
+	} else if IsActivityPubRequest(r) {
 		if !postFound {
 			return ErrCollectionPageNotFound
 		}


### PR DESCRIPTION
This finishes the work started in #766, ensuring that canonical URLs of blogs and posts (not just at their API endpoints) respond correctly to `application/ld+json;...` requests.

Fully addresses issue #564

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
