### PR TITLE
Prevent 500 errors on too-long collection title or description

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -39,7 +39,12 @@ import (
 	"golang.org/x/net/idna"
 )
 
-const collAttrLetterReplyTo = "letter_reply_to"
+const (
+	collAttrLetterReplyTo = "letter_reply_to"
+
+	collMaxLengthTitle       = 255
+	collMaxLengthDescription = 160
+)
 
 type (
 	// TODO: add Direction to db

--- a/database.go
+++ b/database.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/writeas/web-core/silobridge"
 	wf_db "github.com/writefreely/writefreely/db"
+	"github.com/writefreely/writefreely/parse"
 	"net/http"
 	"net/url"
 	"strings"
@@ -862,6 +863,14 @@ func (db *datastore) GetCollectionFromDomain(host string) (*Collection, error) {
 }
 
 func (db *datastore) UpdateCollection(app *App, c *SubmittedCollection, alias string) error {
+	// Truncate fields correctly, so we don't get "Data too long for column" errors in MySQL (writefreely#600)
+	if c.Title != nil {
+		*c.Title = parse.Truncate(*c.Title, collMaxLengthTitle)
+	}
+	if c.Description != nil {
+		*c.Description = parse.Truncate(*c.Description, collMaxLengthDescription)
+	}
+
 	q := query.NewUpdate().
 		SetStringPtr(c.Title, "title").
 		SetStringPtr(c.Description, "description").

--- a/parse/posts.go
+++ b/parse/posts.go
@@ -80,3 +80,12 @@ func TruncToWord(s string, l int) (string, bool) {
 	}
 	return s, truncated
 }
+
+// Truncate truncates the given text to the provided limit, returning the original string if it's shorter than the limit.
+func Truncate(s string, l int) string {
+	c := []rune(s)
+	if len(c) > l {
+		s = string(c[:l])
+	}
+	return s
+}

--- a/templates/user/collection.tmpl
+++ b/templates/user/collection.tmpl
@@ -36,7 +36,7 @@ textarea.section.norm {
 <form name="customize-form" action="/api/collections/{{.Alias}}" method="post" onsubmit="return disableSubmit()">
 <div id="collection-options">
 	<div style="text-align:center">
-		<h1><input type="text" name="title" id="title" value="{{.DisplayTitle}}" placeholder="Title" /></h1>
+		<h1><input type="text" name="title" id="title" value="{{.DisplayTitle}}" placeholder="Title" maxlength="255" /></h1>
 		<p><input type="text" name="description" id="description" value="{{.Description}}" placeholder="Description" maxlength="160" /></p>
 	</div>
 


### PR DESCRIPTION
This truncates long titles and descriptions to the maximum column length, so we don't get errors back from MySQL.

Fixes #600

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
