### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,45 +3,43 @@ version: "3"
 volumes:
   web-keys:
   db-data:
+  config.ini:
+    external: true
 
 networks:
-  external_writefreely:
-  internal_writefreely:
+  external_writefreely: # Used to expose WriteFreely to a reverse proxy for example
+  internal_writefreely: # Used for WriteFreely to communicate with the database
     internal: true
 
 services:
   writefreely-web:
     container_name: "writefreely-web"
-    image: "writeas/writefreely:latest"
-
+    image: "docker.io/writeas/writefreely:latest"
     volumes:
-      - "web-keys:/go/keys"
-      - "./config.ini:/go/config.ini"
-
+      - "web-keys:/go/keys:z"
+      - "./config.ini:/go/config.ini:Z"
     networks:
       - "internal_writefreely"
       - "external_writefreely"
-
     ports:
       - "8080:8080"
-
     depends_on:
       - "writefreely-db"
-
     restart: unless-stopped
 
   writefreely-db:
     container_name: "writefreely-db"
-    image: "mariadb:latest"
-
+    image: "docker.io/mariadb:latest"
     volumes:
-      - "db-data:/var/lib/mysql/data"
-
+      - "db-data:/var/lib/mysql/data:z"
     networks:
       - "internal_writefreely"
-
     environment:
-      - MYSQL_DATABASE=writefreely
-      - MYSQL_ROOT_PASSWORD=changeme
-
+      - MYSQL_RANDOM_ROOT_PASSWORD=true
+      - MYSQL_DATABASE=writefreelydb
+      - MYSQL_USER=writefreely
+      - MYSQL_PASSWORD=changeme
+      # MYSQL_HOST points to itself, which matches the container name
+      # "writefreely-db" for container DNS resolution
+      - MYSQL_HOST=localhost
     restart: unless-stopped

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-docker-compose exec db sh -c 'exec mysql -u root -pchangeme writefreely < /tmp/schema.sql'
-docker exec writefreely_web_1 writefreely --gen-keys
-docker exec -it writefreely_web_1 writefreely --config


### PR DESCRIPTION
I added a few changes to the compose file that make it a bit more readable and interoperable with Podman.

Most notably I changed the thing about the root password for MariaDB to use MYSQL_RANDOM_ROOT_PASSWORD instead. As far as I can tell there's no need for root rights inside the container.

The bash script isn't needed and it was outdated.

---

- [ ] I have signed the [CLA](https://phabricator.write.as/L1)
