### PR TITLE
Fix use of NOW() when getting tagged posts

### DIFF
--- a/database.go
+++ b/database.go
@@ -1320,7 +1320,7 @@ func (db *datastore) GetAllPostsTaggedIDs(c *Collection, tag string, includeFutu
 
 	timeCondition := ""
 	if !includeFuture {
-		timeCondition = "AND created <= NOW()"
+		timeCondition = "AND created <= " + db.now()
 	}
 	var rows *sql.Rows
 	var err error


### PR DESCRIPTION
Quick fix to address the issue in #783 - changes the query in the function that selects tagged posts to use the helper `db.now()` to correctly format for either SQL or sqlite.

I did A/B testing (exact same config, only different binaries) of the build with the fix compared the 0.14.0 release to confirm that this completely addresses the issue.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
