### PR TITLE
Look for custom CSS in static_parent_dir

### DIFF
--- a/app.go
+++ b/app.go
@@ -365,7 +365,7 @@ func pageForReq(app *App, r *http.Request) page.StaticPage {
 	}
 
 	// Use custom style, if file exists
-	if _, err := os.Stat(filepath.Join(staticDir, "local", "custom.css")); err == nil {
+	if _, err := os.Stat(filepath.Join(app.cfg.Server.StaticParentDir, staticDir, "local", "custom.css")); err == nil {
 		p.CustomCSS = true
 	}
 


### PR DESCRIPTION
Previously, it would only check the current directory instead of using the configured `static_parent_dir`. This fixes that.

Closes #792

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
