### PR TITLE
Add Contact page links to footers

### DIFF
--- a/templates/include/footer.tmpl
+++ b/templates/include/footer.tmpl
@@ -8,6 +8,7 @@
 					<a href="/about">about</a>
 					{{if and .LocalTimeline .CanViewReader}}<a href="/read">reader</a>{{end}}
 					{{if .Username}}<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>{{end}}
+					<a href="/contact">contact</a>
 					<a href="/privacy">privacy</a>
 					<p style="font-size: 0.9em">powered by <a href="https://writefreely.org">writefreely</a></p>
 				{{else}}
@@ -25,6 +26,7 @@
 						<ul>
 							<li><a href="/about">about</a></li>
 							{{if and (and (not .SingleUser) .LocalTimeline) .CanViewReader}}<a href="/read">reader</a>{{end}}
+							<li><a href="/contact">contact</a></li>
 							<li><a href="/privacy">privacy</a></li>
 						</ul>
 					</div>

--- a/templates/user/include/footer.tmpl
+++ b/templates/user/include/footer.tmpl
@@ -11,7 +11,7 @@
 			{{if not .SingleUser}}<a href="/about">about</a>{{end}}
 			{{if and (not .SingleUser) .LocalTimeline}}<a href="/read">reader</a>{{end}}
 			<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>
-            {{if not .SingleUser}}<a href="/contact">contact</a>{{end}}
+			{{if not .SingleUser}}<a href="/contact">contact</a>{{end}}
 			{{if not .SingleUser}}<a href="/privacy">privacy</a>{{end}}
       {{if .WFModesty}}
 			<p style="font-size: 0.9em">powered by <a href="https://writefreely.org">writefreely</a></p>

--- a/templates/user/include/footer.tmpl
+++ b/templates/user/include/footer.tmpl
@@ -11,6 +11,7 @@
 			{{if not .SingleUser}}<a href="/about">about</a>{{end}}
 			{{if and (not .SingleUser) .LocalTimeline}}<a href="/read">reader</a>{{end}}
 			<a href="https://writefreely.org/guide/{{.OfficialVersion}}" target="guide">writer's guide</a>
+            {{if not .SingleUser}}<a href="/contact">contact</a>{{end}}
 			{{if not .SingleUser}}<a href="/privacy">privacy</a>{{end}}
       {{if .WFModesty}}
 			<p style="font-size: 0.9em">powered by <a href="https://writefreely.org">writefreely</a></p>


### PR DESCRIPTION
This adds links to the custom Contact Us page (added in v0.14) in all footers.

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
