### PR TITLE
Fix Collection property serialization on API

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -114,9 +114,9 @@ type (
 		Alias        *string         `schema:"alias" json:"alias"`
 		Title        *string         `schema:"title" json:"title"`
 		Description  *string         `schema:"description" json:"description"`
-		StyleSheet   *sql.NullString `schema:"style_sheet" json:"style_sheet"`
-		Script       *sql.NullString `schema:"script" json:"script"`
-		Signature    *sql.NullString `schema:"signature" json:"signature"`
+		StyleSheet   *string         `schema:"style_sheet" json:"style_sheet"`
+		Script       *string         `schema:"script" json:"script"`
+		Signature    *string         `schema:"signature" json:"signature"`
 		Monetization *string         `schema:"monetization_pointer" json:"monetization_pointer"`
 		Verification *string         `schema:"verification_link" json:"verification_link"`
 		LetterReply  *string         `schema:"letter_reply" json:"letter_reply"`

--- a/database.go
+++ b/database.go
@@ -905,9 +905,9 @@ func (db *datastore) UpdateCollection(app *App, c *SubmittedCollection, alias st
 	q := query.NewUpdate().
 		SetStringPtr(c.Title, "title").
 		SetStringPtr(c.Description, "description").
-		SetNullString(c.StyleSheet, "style_sheet").
-		SetNullString(c.Script, "script").
-		SetNullString(c.Signature, "post_signature")
+		SetStringPtr(c.StyleSheet, "style_sheet").
+		SetStringPtr(c.Script, "script").
+		SetStringPtr(c.Signature, "post_signature")
 
 	if c.Format != nil {
 		cf := &CollectionFormat{Format: c.Format.String}


### PR DESCRIPTION
Use standard string instead of sql.NullString for `style_sheet`, `script`, and `signature`.

Addresses #820

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
