### PR TITLE
Version number and healthcheck fixes for Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,1 @@
 Dockerfile
-.git


### PR DESCRIPTION
- Include .git context in Docker build for UI version number
  - Fixes #873
  - Potential caching/performance impact, but it's a really simple solution that doesn't require any special scripting that would break local Docker Compose dev usage and whatnot.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
