### PR TITLE
Add healthcheck dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN make build \
 FROM alpine@sha256:48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86
 
 RUN apk -U upgrade \
-    && apk add --no-cache openssl ca-certificates
+    && apk add --no-cache openssl ca-certificates curl
 
 COPY --from=build --chown=daemon:daemon /stage /go
 


### PR DESCRIPTION
Health check from `Dockerfile` uses `curl` but it is not installed by default. This causes container to be forever unhealthy and thus ignored by other apps, for example Traefik.

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
