### PR TITLE
fixed join on remotefollowers/users to get the date correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,4 +89,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.21
+
+toolchain go1.22.0


### PR DESCRIPTION


There was a missing field from a join on remotefollows and users which was causing subscribers "Since" to output a null date.  

added f.created to the query and aded &f.Created to the scan result.  



---

- [ ] I have signed the [CLA](https://phabricator.write.as/L1)
