### PR TITLE
add f.created to join, add Created to Scan

### DIFF
--- a/database.go
+++ b/database.go
@@ -14,14 +14,15 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"github.com/go-sql-driver/mysql"
-	"github.com/writeas/web-core/silobridge"
-	wf_db "github.com/writefreely/writefreely/db"
-	"github.com/writefreely/writefreely/parse"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/writeas/web-core/silobridge"
+	wf_db "github.com/writefreely/writefreely/db"
+	"github.com/writefreely/writefreely/parse"
 
 	"github.com/guregu/null"
 	"github.com/guregu/null/zero"
@@ -1497,7 +1498,7 @@ ORDER BY created `+order+limitStr, collID, lang)
 }
 
 func (db *datastore) GetAPFollowers(c *Collection) (*[]RemoteUser, error) {
-	rows, err := db.Query("SELECT actor_id, inbox, shared_inbox FROM remotefollows f INNER JOIN remoteusers u ON f.remote_user_id = u.id WHERE collection_id = ?", c.ID)
+	rows, err := db.Query("SELECT actor_id, inbox, shared_inbox, f.created FROM remotefollows f INNER JOIN remoteusers u ON f.remote_user_id = u.id WHERE collection_id = ?", c.ID)
 	if err != nil {
 		log.Error("Failed selecting from followers: %v", err)
 		return nil, impart.HTTPError{http.StatusInternalServerError, "Couldn't retrieve followers."}
@@ -1507,7 +1508,7 @@ func (db *datastore) GetAPFollowers(c *Collection) (*[]RemoteUser, error) {
 	followers := []RemoteUser{}
 	for rows.Next() {
 		f := RemoteUser{}
-		err = rows.Scan(&f.ActorID, &f.Inbox, &f.SharedInbox)
+		err = rows.Scan(&f.ActorID, &f.Inbox, &f.SharedInbox, &f.Created)
 		followers = append(followers, f)
 	}
 	return &followers, nil


### PR DESCRIPTION
resubmitting fix for "subscribed since" null time bug.  

fixed issue with go versioning and formatting.

obtain f.created from join statement and pass into the value pointed at by RemoteUser argument.  

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
