### PR TITLE
Fix Admin and Invite links never showing on Reader nav

### DIFF
--- a/read.go
+++ b/read.go
@@ -229,11 +229,9 @@ func showLocalTimeline(app *App, w http.ResponseWriter, r *http.Request, page in
 		TotalPages:  ttlPages,
 		SelTopic:    tag,
 	}
-	if app.cfg.App.Chorus {
-		u := getUserSession(app, r)
-		d.IsAdmin = u != nil && u.IsAdmin()
-		d.CanInvite = canUserInvite(app.cfg, d.IsAdmin)
-	}
+	u := getUserSession(app, r)
+	d.IsAdmin = u != nil && u.IsAdmin()
+	d.CanInvite = canUserInvite(app.cfg, d.IsAdmin)
 	c, err := getReaderSection(app)
 	if err != nil {
 		return err


### PR DESCRIPTION
Continuing work in #878, this ensures other nav links (Admin Dashboard, Invite People) show up correctly on the Reader, when necessary.

---

- ☑ I have signed the [CLA](https://phabricator.write.as/L1)
