### PR TITLE
Fix Docker healthcheck with wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,4 @@ USER daemon
 ENTRYPOINT ["cmd/writefreely/writefreely"]
 
 HEALTHCHECK --start-period=5s --interval=15s --timeout=5s \
-    CMD curl -fSs http://localhost:8080/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1


### PR DESCRIPTION
- Change Docker healthcheck to `wget`
  - No issue open for this one, but the healthcheck fails because `curl` is not available on the image. Switched to `wget` and the best practice args for a healthcheck
  - Alternative to #875 that doesn't install any new packages on the image

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
