### PR TITLE
add client_id and client_secret to exchangeOauthCode form

### DIFF
--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -70,6 +70,8 @@ func (c genericOauthClient) buildLoginURL(state string) (string, error) {
 
 func (c genericOauthClient) exchangeOauthCode(ctx context.Context, code string) (*TokenResponse, error) {
 	form := url.Values{}
+	form.Add("client_id", c.ClientID)
+	form.Add("client_secret", c.ClientSecret)
 	form.Add("grant_type", "authorization_code")
 	form.Add("redirect_uri", c.CallbackLocation)
 	form.Add("scope", c.Scope)


### PR DESCRIPTION
Some OAuth applications require `client_id` and `client_secret` to be present during the OAuth code exchange. This pull request adds these two params to the exchangeOauthCode form to meet their expectations.

Fixes #888 

---

- [x] I have signed the [CLA](https://phabricator.write.as/L1)
