### PR TITLE
Correctly show 404 page on /sitemap.xml on multi-user instances

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,6 +30,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Set up QEMU for cross-building
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.0.0
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
@@ -56,6 +64,7 @@ jobs:
         uses: docker/build-push-action@v5.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # Build image
-# SHA256 of golang:1.21-alpine3.18 linux/amd64
-FROM golang@sha256:f475434ea2047a83e9ba02a1da8efc250fa6b2ed0e9e8e4eb8c5322ea6997795 as build
+FROM golang:1.21-alpine3.18 as build
 
 LABEL org.opencontainers.image.source="https://github.com/writefreely/writefreely"
 LABEL org.opencontainers.image.description="WriteFreely is a clean, minimalist publishing platform made for writers. Start a blog, share knowledge within your organization, or build a community around the shared act of writing."
@@ -31,8 +30,7 @@ RUN make build \
       /stage
 
 # Final image
-# SHA256 of alpine:3.18.4 linux/amd64
-FROM alpine@sha256:48d9183eb12a05c99bcc0bf44a003607b8e941e1d4f41f9ad12bdcc4b5672f86
+FROM alpine:3.18.4
 
 RUN apk -U upgrade \
     && apk add --no-cache openssl ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,4 +45,4 @@ USER daemon
 ENTRYPOINT ["cmd/writefreely/writefreely"]
 
 HEALTHCHECK --start-period=5s --interval=15s --timeout=5s \
-    CMD curl -fSs http://localhost:8080/ || exit 1
+    CMD wget --no-verbose --tries=1 --spider http://localhost:8080/ || exit 1

--- a/posts.go
+++ b/posts.go
@@ -314,6 +314,8 @@ func handleViewPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	// Display reserved page if that is requested resource
 	if t, ok := pages[r.URL.Path[1:]+".tmpl"]; ok {
 		return handleTemplatedPage(app, w, r, t)
+	} else if r.URL.Path == "/sitemap.xml" && !app.cfg.App.SingleUser {
+		return impart.HTTPError{Status: http.StatusNotFound, Message: "Page not found."}
 	} else if (strings.Contains(r.URL.Path, ".") && !isRaw && !isMarkdown) || r.URL.Path == "/robots.txt" || r.URL.Path == "/manifest.json" {
 		// Serve static file
 		app.shttp.ServeHTTP(w, r)


### PR DESCRIPTION
Sitemaps are only meant for individual blogs right now, so instead of invalid HTML getting returned, we'll properly catch the issue and show a user-friendly "not found" page.

Fixes #941

---

- ☑ I have signed the [CLA](https://todo.musing.studio/L1)
