### PR TITLE
Bump Go from v1.19 to v1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,4 +90,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-go 1.19
+go 1.21


### PR DESCRIPTION
This is needed to fix a compilation error after merging #1011.

---

- ☑ I have signed the [CLA](https://todo.musing.studio/L1)
