### PR TITLE
Docker for Production

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,0 +1,34 @@
+FROM golang:alpine AS build
+
+LABEL org.opencontainers.image.source="https://github.com/writefreely/writefreely"
+LABEL org.opencontainers.image.description="WriteFreely is a clean, minimalist publishing platform made for writers. Start a blog, share knowledge within your organization, or build a community around the shared act of writing."
+
+RUN apk update --no-cache && \
+	apk upgrade --no-cache && \
+	apk add --no-cache nodejs npm make g++ git sqlite-dev patch && \
+	npm install -g less less-plugin-clean-css && \
+	mkdir -p /go/src/github.com/writefreely/writefreely
+
+COPY . /go/src/github.com/writefreely/writefreely
+WORKDIR /go/src/github.com/writefreely/writefreely
+ENV NODE_OPTIONS=--openssl-legacy-provider
+RUN cat ossl_legacy.cnf >> /etc/ssl/openssl.cnf && \
+	make build && \
+	make ui
+
+FROM alpine
+
+RUN apk update --no-cache && \
+	apk upgrade --no-cache && \
+	apk add --no-cache openssl ca-certificates && \
+	mkdir /usr/share/writefreely
+
+COPY --from=build /go/src/github.com/writefreely/writefreely/cmd/writefreely/writefreely /usr/bin
+COPY --from=build /go/src/github.com/writefreely/writefreely/pages /usr/share/writefreely/pages
+COPY --from=build /go/src/github.com/writefreely/writefreely/static /usr/share/writefreely/static
+COPY --from=build /go/src/github.com/writefreely/writefreely/templates /usr/share/writefreely/templates
+
+ENV WRITEFREELY_DOCKER=True
+ENV HOME=/data
+WORKDIR /data
+CMD ["/usr/bin/writefreely"]

--- a/config/setup.go
+++ b/config/setup.go
@@ -12,12 +12,14 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/fatih/color"
 	"github.com/manifoldco/promptui"
 	"github.com/mitchellh/go-wordwrap"
 	"github.com/writeas/web-core/auth"
-	"strconv"
-	"strings"
 )
 
 type SetupData struct {
@@ -79,6 +81,8 @@ func Configure(fname string, configSections string) (*SetupData, error) {
 		}
 		isDevEnv := envType == "Development"
 		isStandalone := envType == "Production, standalone"
+
+		_, isDocker := os.LookupEnv("WRITEFREELY_DOCKER")
 
 		data.Config.Server.Dev = isDevEnv
 
@@ -148,6 +152,16 @@ func Configure(fname string, configSections string) (*SetupData, error) {
 		} else {
 			data.Config.Server.TLSCertPath = ""
 			data.Config.Server.TLSKeyPath = ""
+		}
+
+		// If running in docker:
+		// 1. always bind to 0.0.0.0 instead of localhost
+		// 2. set paths of static files in UNIX manners
+		if !isDevEnv && isDocker {
+			data.Config.Server.TemplatesParentDir = "/usr/share/writefreely"
+			data.Config.Server.StaticParentDir = "/usr/share/writefreely"
+			data.Config.Server.PagesParentDir = "/usr/share/writefreely"
+			data.Config.Server.Bind = "0.0.0.0"
 		}
 
 		fmt.Println()

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,25 @@
+services:
+  app:
+    image: writefreely
+    container_name: writefreely
+    volumes:
+      - ./data:/data
+    ports:
+      - 127.0.0.1:8080:8080
+    depends_on:
+      - db
+    restart: unless-stopped
+
+  db:
+    image: lscr.io/linuxserver/mariadb
+    container_name: writefreely-mariadb
+    volumes: 
+      - ./db:/config
+    environment:
+      - PUID=65534
+      - PGID=65534
+      - TZ=Etc/UTC
+      - MYSQL_DATABASE=writefreely
+      - MYSQL_USER=writefreely
+      - MYSQL_PASSWORD=P@ssw0rd
+    restart: unless-stopped


### PR DESCRIPTION
This patch contains necessary changes to enable users to run writefreely in docker for production purposes.

Besides, a sample `docker-compose.yml` file, named `docker-compose.prod.yml`, is provided with MariaDB as database.

### Full sample procedure for setup

1. `cd` to directory of writefreely repository, check out `docker-prod` branch
2. build docker image by `docker build -t writefreely .`
3. create a directory, e.g. `/srv/docker/writefreely`
4. copy `docker-compose.prod.yml` to `/srv/docker/writefreely`
5. `cd /srv/docker/writefreely`
6. `docker compose run -it --rm app writefreely config start` and run normal setup procedure, **choose "Production, behind reverse proxy" mode**, input database name, username and password specified in `docker-compose.yml`, set database host to `db`.
7. `docker compose run -it --rm app writefreely keys generate` to generate keys
8. `docker compose up -d`
9. checkout http://localhost:8080 with web browser

Besides, a sample reverse proxy configuration with Apache HTTP Server is available as below:

```
<VirtualHost *:443>
	ServerName domain.tld
	SSLEngine On
	SSLCertificateFile /path/to/ssl.crt
	SSLCertificateKeyFile /path/to/ssl.key

	ProxyPass / "http://127.0.0.1:8080/" nocanon
	ProxyAddHeaders Off
	ProxyPreserveHost On
	ProxyErrorOverride Off

	RequestHeader set "X-Real-IP" expr=%{REMOTE_ADDR}
	RequestHeader set "X-Forwarded-For" expr=%{REMOTE_ADDR}
	RequestHeader set "X-Forwarded-Port" expr=%{SERVER_PORT}
	RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
	RequestHeader set "X-Forwarded-Ssl" expr=%{HTTPS}

	Header unset server
</VirtualHost>
```

I am running this setup in my production server, thus, I would like to share it with the community. :-D

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
