### PR TITLE
Fix `follow` handle in nodeinfo

### DIFF
--- a/nodeinfo.go
+++ b/nodeinfo.go
@@ -46,7 +46,7 @@ func nodeInfoConfig(db *datastore, cfg *config.Config) *nodeinfo.Config {
 			Software: nodeinfo.SoftwareMeta{
 				HomePage: softwareURL,
 				GitHub:   "https://github.com/writefreely/writefreely",
-				Follow:   "https://writing.exchange/@write_as",
+				Follow:   "https://writing.exchange/@writefreely",
 			},
 			MaxBlogs:     cfg.App.MaxBlogs,
 			PublicReader: cfg.App.LocalTimeline,


### PR DESCRIPTION
Use @writefreely@writing.exchange instead of @write_as@writing.exchange.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
