### PR TITLE
Fix broken links in drafts loaded with "load more" #1054

### DIFF
--- a/static/js/posts.js
+++ b/static/js/posts.js
@@ -193,16 +193,17 @@ var createPostEl = function(post, owned, singleUser) {
 	let p = H.createPost(post.id, "", post.body)
 	var title = (post.title || p.title || post.id);
 	title = title.replace(/</g, "&lt;");
+	var postLink = (singleUser ? '/d/' : '/') + post.id + '/edit'
 	$post.id = 'post-' + post.id;
 	$post.className = 'post';
-	$post.innerHTML = '<h3><a href="/' + post.id + '">' + title + '</a></h3>';
+	$post.innerHTML = '<h3><a href="' + postLink + '">' + title + '</a></h3>';
 
 	var posted = "";
 	if (post.created) {
 		posted = getFormattedDate(new Date(post.created))
 	}
 	var hasDraft = H.exists('draft' + post.id);
-	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="' + (singleUser ? '/d/' : '/') + post.id + '/edit">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
+	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="' + postLink + '">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
 
 	if (post.error) {
 		$post.innerHTML += '<p class="error"><strong>Sync error:</strong> ' + post.error + ' <nav><a href="#" onclick="localPosts.dismissError(event, this)">dismiss</a> <a href="#" onclick="localPosts.deletePost(event, this, \''+post.id+'\')">remove post</a></nav></p>';

--- a/static/js/posts.js
+++ b/static/js/posts.js
@@ -193,7 +193,7 @@ var createPostEl = function(post, owned, singleUser) {
 	let p = H.createPost(post.id, "", post.body)
 	var title = (post.title || p.title || post.id);
 	title = title.replace(/</g, "&lt;");
-	var postLink = (singleUser ? '/d/' : '/') + post.id + '/edit'
+	var postLink = (singleUser ? '/d/' : '/') + post.id
 	$post.id = 'post-' + post.id;
 	$post.className = 'post';
 	$post.innerHTML = '<h3><a href="' + postLink + '">' + title + '</a></h3>';
@@ -203,7 +203,7 @@ var createPostEl = function(post, owned, singleUser) {
 		posted = getFormattedDate(new Date(post.created))
 	}
 	var hasDraft = H.exists('draft' + post.id);
-	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="' + postLink + '">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
+	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="' + postLink + '/edit">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
 
 	if (post.error) {
 		$post.innerHTML += '<p class="error"><strong>Sync error:</strong> ' + post.error + ' <nav><a href="#" onclick="localPosts.dismissError(event, this)">dismiss</a> <a href="#" onclick="localPosts.deletePost(event, this, \''+post.id+'\')">remove post</a></nav></p>';

--- a/static/js/posts.js
+++ b/static/js/posts.js
@@ -188,7 +188,7 @@ var movePostHTML = function(postID) {
 	}
 	return $tmpl.innerHTML.replace(/POST_ID/g, postID);
 }
-var createPostEl = function(post, owned) {
+var createPostEl = function(post, owned, singleUser) {
 	var $post = document.createElement('div');
 	let p = H.createPost(post.id, "", post.body)
 	var title = (post.title || p.title || post.id);
@@ -202,7 +202,7 @@ var createPostEl = function(post, owned) {
 		posted = getFormattedDate(new Date(post.created))
 	}
 	var hasDraft = H.exists('draft' + post.id);
-	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="/pad/' + post.id + '">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
+	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="' + (singleUser ? '/d/' : '/') + post.id + '/edit">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
 
 	if (post.error) {
 		$post.innerHTML += '<p class="error"><strong>Sync error:</strong> ' + post.error + ' <nav><a href="#" onclick="localPosts.dismissError(event, this)">dismiss</a> <a href="#" onclick="localPosts.deletePost(event, this, \''+post.id+'\')">remove post</a></nav></p>';

--- a/templates/user/articles.tmpl
+++ b/templates/user/articles.tmpl
@@ -202,8 +202,9 @@ function loadMorePosts() {
 		if (http.readyState == 4) {
 			if (http.status == 200) {
 				var data = JSON.parse(http.responseText);
+				var singleUser = {{ .SingleUser }};
 				for (var i=0; i<data.data.length; i++) {
-					$posts.el.appendChild(createPostEl(data.data[i], true));
+					$posts.el.appendChild(createPostEl(data.data[i], true, singleUser));
 				}
 				if (data.data.length < 10) {
 					$loadMore.el.parentNode.removeChild($loadMore.el);


### PR DESCRIPTION
### Description
This PR fixes broken edit links for drafts when loaded via 'load more' by dynamically generating the edit links based on the `single_user` config value.

Previously, drafts loaded with 'load more' had broken links because the link generation didn't account for the single-user mode and the path /pad/ seems to be deprecated.

Original issue description: [Issue #1054](https://github.com/writefreely/writefreely/issues/1054).

### Changes Made
- In `posts.js`, I introduced a new argument of `singleUser` to the `createPostEl` method
- In `articles.tmpl`, I pass down the single_user boolean to the `createPostEl` method

### How to Test
To verify the edit links work correctly in both single-user and multi-user modes:

1. Ensure you have more than 10 drafts
2. Set `single_user` = `true` in config.ini
3. Restart the app
4. Go to Drafts and click "Load more..."
5. Click "Edit" on one of the loaded drafts:
    - In single-user mode, the link should look like `/d/POSTID/edit`
    - In multi-user mode, it should look like `/POSTID/edit`
6. Set `single_user` = `false` in config.ini
7. Restart the app and repeat steps 4-5

### Related Ticket
https://github.com/writefreely/writefreely/issues/1054

### Additional Notes
I tried to see if introducing the new argument would cause any issues when the method is called elsewhere. I found that the other usages are in `posts.js` under `delPost` method. I am not sure how to test the functionality under the comment "Fill in full page of posts" to see if it is adversely affected by the introduction of the new method argument.

I found another minor bug while testing this and will open a separate issue for it. A quick summary: When deleting drafts, it doesn't refill the 10 latest drafts, so you can delete all 10 until all that is left is the Load more... link. Once you click it, the remaining drafts populate.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)