### PR TITLE
Support ActivityPub Likes

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -48,7 +48,7 @@ const (
 
 var (
 	apCollectionPostIRIRegex = regexp.MustCompile("/api/collections/([a-z0-9\\-]+)/posts/([a-z0-9\\-]+)$")
-	apDraftPostIRIRegex      = regexp.MustCompile("/api/posts/([a-z0-9\\-]{12,16})$")
+	apDraftPostIRIRegex      = regexp.MustCompile("/api/posts/([a-z0-9\\-])$")
 )
 
 var instanceColl *Collection

--- a/activitypub.go
+++ b/activitypub.go
@@ -392,7 +392,13 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 			   }, 0)
 			*/
 
+			if obj == nil {
+				return fmt.Errorf("didn't get ObjectIRI to Like")
+			}
 			likePostID, err = parsePostIDFromURL(app, obj)
+			if err != nil {
+				return err
+			}
 
 			// Finally, get actor information
 			_, from := l.GetActor(0)
@@ -458,7 +464,13 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 
 					_, from := like.GetActor(0)
 					obj := like.Raw().GetObjectIRI(0)
+					if obj == nil {
+						return fmt.Errorf("didn't get ObjectIRI for Undo Like")
+					}
 					unlikePostID, err = parsePostIDFromURL(app, obj)
+					if err != nil {
+						return err
+					}
 					fullActor, remoteUser, err = getActor(app, from.String())
 					if err != nil {
 						return err

--- a/activitypub.go
+++ b/activitypub.go
@@ -48,7 +48,7 @@ const (
 
 var (
 	apCollectionPostIRIRegex = regexp.MustCompile("/api/collections/([a-z0-9\\-]+)/posts/([a-z0-9\\-]+)$")
-	apDraftPostIRIRegex      = regexp.MustCompile("/api/posts/([a-z0-9\\-])$")
+	apDraftPostIRIRegex      = regexp.MustCompile("/api/posts/([a-z0-9\\-]+)$")
 )
 
 var instanceColl *Collection

--- a/activitypub.go
+++ b/activitypub.go
@@ -573,7 +573,7 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 			remoteUserID, err = apAddRemoteUser(app, t, fullActor)
 		}
 
-		// Add follow
+		// Remove like
 		_, err = t.Exec("DELETE FROM remote_likes WHERE post_id = ? AND remote_user_id = ?", unlikePostID, remoteUserID)
 		if err != nil {
 			t.Rollback()

--- a/activitypub.go
+++ b/activitypub.go
@@ -535,7 +535,7 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 		}
 
 		// Add like
-		_, err = t.Exec("INSERT INTO remote_likes (post_id, remote_user_id, created) VALUES (?, ?, NOW())", likePostID, remoteUserID)
+		_, err = t.Exec("INSERT INTO remote_likes (post_id, remote_user_id, created) VALUES (?, ?, "+app.db.now()+")", likePostID, remoteUserID)
 		if err != nil {
 			if !app.db.isDuplicateKeyErr(err) {
 				t.Rollback()

--- a/database_activitypub.go
+++ b/database_activitypub.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2024 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package writefreely
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/writeas/web-core/activitystreams"
+	"github.com/writeas/web-core/log"
+)
+
+func apAddRemoteUser(app *App, t *sql.Tx, fullActor *activitystreams.Person) (int64, error) {
+	// Add remote user locally, since it wasn't found before
+	res, err := t.Exec("INSERT INTO remoteusers (actor_id, inbox, shared_inbox, url) VALUES (?, ?, ?, ?)", fullActor.ID, fullActor.Inbox, fullActor.Endpoints.SharedInbox, fullActor.URL)
+	if err != nil {
+		t.Rollback()
+		return -1, fmt.Errorf("couldn't add new remoteuser in DB: %v", err)
+	}
+
+	remoteUserID, err := res.LastInsertId()
+	if err != nil {
+		t.Rollback()
+		return -1, fmt.Errorf("no lastinsertid for followers, rolling back: %v", err)
+	}
+
+	// Add in key
+	_, err = t.Exec("INSERT INTO remoteuserkeys (id, remote_user_id, public_key) VALUES (?, ?, ?)", fullActor.PublicKey.ID, remoteUserID, fullActor.PublicKey.PublicKeyPEM)
+	if err != nil {
+		if !app.db.isDuplicateKeyErr(err) {
+			t.Rollback()
+			log.Error("Couldn't add follower keys in DB: %v\n", err)
+			return -1, fmt.Errorf("couldn't add follower keys in DB: %v", err)
+		} else {
+			t.Rollback()
+			log.Error("Couldn't add follower keys in DB: %v\n", err)
+			return -1, fmt.Errorf("couldn't add follower keys in DB: %v", err)
+		}
+	}
+
+	return remoteUserID, nil
+}

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -71,6 +71,7 @@ var migrations = []Migration{
 	New("support newsletters", supportLetters),                      // V12 -> V13
 	New("support password resetting", supportPassReset),             // V13 -> V14
 	New("speed up blog post retrieval", addPostRetrievalIndex),      // V14 -> V15
+	New("support ActivityPub likes", supportRemoteLikes),            // V15 -> V16 (v0.16.0)
 }
 
 // CurrentVer returns the current migration version the application is on

--- a/migrations/v16.go
+++ b/migrations/v16.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2024 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package migrations
+
+func supportRemoteLikes(db *datastore) error {
+	t, err := db.Begin()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	_, err = t.Exec(`CREATE TABLE remote_likes (
+	post_id        ` + db.typeChar(16) + ` NOT NULL,
+	remote_user_id ` + db.typeInt() + ` NOT NULL,
+	created        ` + db.typeDateTime() + ` NOT NULL,
+	PRIMARY KEY (post_id,remote_user_id)
+)`)
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	err = t.Commit()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	return nil
+}

--- a/posts.go
+++ b/posts.go
@@ -105,6 +105,7 @@ type (
 		Created        time.Time     `db:"created" json:"created"`
 		Updated        time.Time     `db:"updated" json:"updated"`
 		ViewCount      int64         `db:"view_count" json:"-"`
+		LikeCount      int64         `db:"like_count" json:"likes"`
 		Title          zero.String   `db:"title" json:"title"`
 		HTMLTitle      template.HTML `db:"title" json:"-"`
 		Content        string        `db:"content" json:"body"`
@@ -127,6 +128,7 @@ type (
 		IsTopLevel  bool           `json:"-"`
 		DisplayDate string         `json:"-"`
 		Views       int64          `json:"views"`
+		Likes       int64          `json:"likes"`
 		Owner       *PublicUser    `json:"-"`
 		IsOwner     bool           `json:"-"`
 		URL         string         `json:"url,omitempty"`
@@ -1184,6 +1186,7 @@ func fetchPostProperty(app *App, w http.ResponseWriter, r *http.Request) error {
 func (p *Post) processPost() PublicPost {
 	res := &PublicPost{Post: p, Views: 0}
 	res.Views = p.ViewCount
+	res.Likes = p.LikeCount
 	// TODO: move to own function
 	loc := monday.FuzzyLocale(p.Language.String)
 	res.DisplayDate = monday.Format(p.Created, monday.LongFormatsByLocale[loc], loc)

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -55,6 +55,7 @@
 				{{range .PinnedPosts}}<a class="pinned{{if eq .Slug.String $.Slug.String}} selected{{end}}" href="{{if not $.SingleUser}}/{{$.Collection.Alias}}/{{.Slug.String}}{{else}}{{.CanonicalURL $.Host}}{{end}}">{{.PlainDisplayTitle}}</a>{{end}}
 				{{end}}
 				{{ if and .IsOwner .IsFound }}<span class="views" dir="ltr"><strong>{{largeNumFmt .Views}}</strong> {{pluralize "view" "views" .Views}}</span>
+                {{if .Likes}}<span class="views" dir="ltr"><strong>{{largeNumFmt .Likes}}</strong> {{pluralize "like" "likes" .Likes}}</span>{{end}}
 				<a class="xtra-feature" href="/{{if not .SingleUser}}{{.Collection.Alias}}/{{end}}{{.Slug.String}}/edit" dir="{{.Direction}}">Edit</a>
 				{{if .IsPinned}}<a class="xtra-feature unpin" href="/{{.Collection.Alias}}/{{.Slug.String}}/unpin" dir="{{.Direction}}" onclick="unpinPost(event, '{{.ID}}')">Unpin</a>{{end}}
 				{{ end }}

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 
 		<title>{{.PlainDisplayTitle}} {{localhtml "title dash" .Language.String}} {{.Collection.DisplayTitle}}</title>
-		
+
 		<link rel="stylesheet" type="text/css" href="/css/write.css" />
 		{{if .CustomCSS}}<link rel="stylesheet" type="text/css" href="/local/custom.css" />{{end}}
 		<link rel="shortcut icon" href="/favicon.ico" />
@@ -45,7 +45,7 @@
 
 	</head>
 	<body id="post">
-		
+
 		<div id="overlay"></div>
 
 		<header>
@@ -61,7 +61,7 @@
 				{{ end }}
 			</nav>
 		</header>
-		
+
 		{{if .Silenced}}
 			{{template "user-silenced"}}
 		{{end}}
@@ -71,7 +71,7 @@
 		<footer dir="ltr"><hr><nav><p style="font-size: 0.9em">{{localhtml "published with write.as" .Language.String}}</p></nav></footer>
 		{{ end }}
 	</body>
-	
+
 	{{if .Collection.CanShowScript}}
 		{{range .Collection.ExternalScripts}}<script type="text/javascript" src="{{.}}" async></script>{{end}}
 		{{if .Collection.Script}}<script type="text/javascript">{{.Collection.ScriptDisplay}}</script>{{end}}

--- a/templates/user/stats.tmpl
+++ b/templates/user/stats.tmpl
@@ -51,11 +51,13 @@ td.none {
 			<th>Post</th>
 			{{if not .Collection}}<th>Blog</th>{{end}}
 			<th class="num">Total Views</th>
+			{{if .Federation}}<th class="num">Likes</th>{{end}}
 		</tr>
 		{{range .TopPosts}}<tr>
 			<td style="word-break: break-all;"><a href="{{if .Collection}}{{.Collection.CanonicalURL}}{{.Slug.String}}{{else}}/{{.ID}}{{end}}">{{if ne .DisplayTitle ""}}{{.DisplayTitle}}{{else}}<em>{{.ID}}</em>{{end}}</a></td>
 			{{ if not $.Collection }}<td>{{if .Collection}}<a href="{{.Collection.CanonicalURL}}">{{.Collection.Title}}</a>{{else}}<em>Draft</em>{{end}}</td>{{ end }}
 			<td class="num">{{.ViewCount}}</td>
+			{{if $.Federation}}<td class="num">{{.LikeCount}}</td>{{end}}
 		</tr>{{end}}
 	</table>
 


### PR DESCRIPTION
This adds support for the `Like` activity from the fediverse. If a post has any Likes, the number will show up next to the number of Views on each individual post page. You'll also see a new "Likes" column on your blog's Stats page.

Includes database changes -- update with `writefreely db migrate`.

Closes [T906](https://todo.musing.studio/T906) and partially fixes #697.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
