### PR TITLE
Support SMTP email configuration

### DIFF
--- a/app.go
+++ b/app.go
@@ -428,15 +428,11 @@ func Initialize(apper Apper, debug bool) (*App, error) {
 
 	initActivityPub(apper.App())
 
-	if apper.App().cfg.Email.Domain != "" || apper.App().cfg.Email.MailgunPrivate != "" {
-		if apper.App().cfg.Email.Domain == "" {
-			log.Error("[FAILED] Starting publish jobs queue: no [letters]domain config value set.")
-		} else if apper.App().cfg.Email.MailgunPrivate == "" {
-			log.Error("[FAILED] Starting publish jobs queue: no [letters]mailgun_private config value set.")
-		} else {
-			log.Info("Starting publish jobs queue...")
-			go startPublishJobsQueue(apper.App())
-		}
+	if apper.App().cfg.Email.Enabled() {
+		log.Info("Starting publish jobs queue...")
+		go startPublishJobsQueue(apper.App())
+	} else {
+		log.Error("[FAILED] Starting publish jobs queue: no email provider is configured.")
 	}
 
 	// Handle local timeline, if enabled

--- a/config/config.go
+++ b/config/config.go
@@ -171,6 +171,14 @@ type (
 	}
 
 	EmailCfg struct {
+		// SMTP configuration values
+		Host           string `ini:"smtp_host"`
+		Port           int    `ini:"smtp_port"`
+		Username       string `ini:"smtp_username"`
+		Password       string `ini:"smtp_password"`
+		EnableStartTLS bool   `ini:"smtp_enable_start_tls"`
+
+		// Mailgun configuration values
 		Domain         string `ini:"domain"`
 		MailgunPrivate string `ini:"mailgun_private"`
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -252,7 +252,7 @@ func (ac *AppCfg) LandingPath() string {
 
 func (lc EmailCfg) Enabled() bool {
 	return (lc.Domain != "" && lc.MailgunPrivate != "") ||
-	lc.Username != "" && lc.Password != "" && lc.Host != "" && lc.Port > 0
+		lc.Username != "" && lc.Password != "" && lc.Host != "" && lc.Port > 0
 }
 
 func (ac AppCfg) SignupPath() string {

--- a/config/config.go
+++ b/config/config.go
@@ -181,6 +181,7 @@ type (
 		// Mailgun configuration values
 		Domain         string `ini:"domain"`
 		MailgunPrivate string `ini:"mailgun_private"`
+		MailgunEurope  bool   `ini:"mailgun_europe"`
 	}
 
 	// Config holds the complete configuration for running a writefreely instance

--- a/config/config.go
+++ b/config/config.go
@@ -251,7 +251,8 @@ func (ac *AppCfg) LandingPath() string {
 }
 
 func (lc EmailCfg) Enabled() bool {
-	return lc.Domain != "" && lc.MailgunPrivate != ""
+	return (lc.Domain != "" && lc.MailgunPrivate != "") ||
+	lc.Username != "" && lc.Password != "" && lc.Host != "" && lc.Port > 0
 }
 
 func (ac AppCfg) SignupPath() string {

--- a/email.go
+++ b/email.go
@@ -417,7 +417,7 @@ Sent to %recipient.to%. Unsubscribe: ` + p.Collection.CanonicalURL() + `email/un
 	for _, s := range subs {
 		e := s.FinalEmail(app.keys)
 		log.Info("[email] Adding %s", e)
-		err = m.AddRecipientAndVariables(e, map[string]interface{}{
+		err = m.AddRecipientAndVariables(e, map[string]string{
 			"id":    s.ID,
 			"to":    e,
 			"token": s.Token,

--- a/email.go
+++ b/email.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/aymerick/douceur/inliner"
 	"github.com/gorilla/mux"
-	"github.com/mailgun/mailgun-go"
 	stripmd "github.com/writeas/go-strip-markdown/v2"
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/data"
@@ -308,14 +307,14 @@ Originally published on ` + p.Collection.DisplayTitle() + ` (` + p.Collection.Ca
 
 Sent to %recipient.to%. Unsubscribe: ` + p.Collection.CanonicalURL() + `email/unsubscribe/%recipient.id%?t=%recipient.token%`
 
-	gun := mailgun.NewMailgun(app.cfg.Email.Domain, app.cfg.Email.MailgunPrivate)
-
-	if app.cfg.Email.MailgunEurope {
-		gun.SetAPIBase("https://api.eu.mailgun.net/v3")
+	mlr, err := mailer.New(app.cfg.Email)
+	if err != nil {
+		return err
 	}
-
-
-	m := mailgun.NewMessage(p.Collection.DisplayTitle()+" <"+p.Collection.Alias+"@"+app.cfg.Email.Domain+">", stripmd.Strip(p.DisplayTitle()), plainMsg)
+	m, err := mlr.NewMessage(p.Collection.DisplayTitle()+" <"+p.Collection.Alias+"@"+app.cfg.Email.Domain+">", stripmd.Strip(p.DisplayTitle()), plainMsg)
+	if err != nil {
+		return err
+	}
 	replyTo := app.db.GetCollectionAttribute(collID, collAttrLetterReplyTo)
 	if replyTo != "" {
 		m.SetReplyTo(replyTo)
@@ -412,7 +411,7 @@ Sent to %recipient.to%. Unsubscribe: ` + p.Collection.CanonicalURL() + `email/un
 		return err
 	}
 
-	m.SetHtml(html)
+	m.SetHTML(html)
 
 	log.Info("[email] Adding %d recipient(s)", len(subs))
 	for _, s := range subs {
@@ -428,8 +427,8 @@ Sent to %recipient.to%. Unsubscribe: ` + p.Collection.CanonicalURL() + `email/un
 		}
 	}
 
-	res, _, err := gun.Send(m)
-	log.Info("[email] Send result: %s", res)
+	err = mlr.Send(m)
+	log.Info("[email] Email sent")
 	if err != nil {
 		log.Error("Unable to send post email: %v", err)
 		return err

--- a/email.go
+++ b/email.go
@@ -309,6 +309,12 @@ Originally published on ` + p.Collection.DisplayTitle() + ` (` + p.Collection.Ca
 Sent to %recipient.to%. Unsubscribe: ` + p.Collection.CanonicalURL() + `email/unsubscribe/%recipient.id%?t=%recipient.token%`
 
 	gun := mailgun.NewMailgun(app.cfg.Email.Domain, app.cfg.Email.MailgunPrivate)
+
+	if app.cfg.Email.MailgunEurope {
+		gun.SetAPIBase("https://api.eu.mailgun.net/v3")
+	}
+
+
 	m := mailgun.NewMessage(p.Collection.DisplayTitle()+" <"+p.Collection.Alias+"@"+app.cfg.Email.Domain+">", stripmd.Strip(p.DisplayTitle()), plainMsg)
 	replyTo := app.db.GetCollectionAttribute(collID, collAttrLetterReplyTo)
 	if replyTo != "" {

--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,8 @@ require (
 	golang.org/x/net v0.30.0
 )
 
+require github.com/xhit/go-simple-mail/v2 v2.16.0
+
 require (
 	code.as/core/socks v1.0.0 // indirect
 	filippo.io/edwards25519 v1.1.0 // indirect
@@ -82,6 +84,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
+	github.com/toorop/go-dkim v0.0.0-20201103131630-e1cd1a0a5208 // indirect
 	github.com/writeas/go-writeas/v2 v2.0.2 // indirect
 	github.com/writeas/openssl-go v1.0.0 // indirect
 	github.com/writeas/slug v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -177,6 +177,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/toorop/go-dkim v0.0.0-20201103131630-e1cd1a0a5208 h1:PM5hJF7HVfNWmCjMdEfbuOBNXSVF2cMFGgQTPdKCbwM=
+github.com/toorop/go-dkim v0.0.0-20201103131630-e1cd1a0a5208/go.mod h1:BzWtXXrXzZUvMacR0oF/fbDDgUPO8L36tDMmRAf14ns=
 github.com/urfave/cli/v2 v2.27.4 h1:o1owoI+02Eb+K107p27wEX9Bb8eqIoZCfLXloLUSWJ8=
 github.com/urfave/cli/v2 v2.27.4/go.mod h1:m4QzxcD2qpra4z7WhzEGn74WZLViBnMpb1ToCAKdGRQ=
 github.com/writeas/activity v0.1.2 h1:Y12B5lIrabfqKE7e7HFCWiXrlfXljr9tlkFm2mp7DgY=
@@ -212,6 +214,8 @@ github.com/writefreely/go-gopher v0.0.0-20220429181814-40127126f83b h1:h3NzB8OZ5
 github.com/writefreely/go-gopher v0.0.0-20220429181814-40127126f83b/go.mod h1:T2UVVzt+R5KSSZe2xRSytnwc2M9AoDegi7foeIsik+M=
 github.com/writefreely/go-nodeinfo v1.2.0 h1:La+YbTCvmpTwFhBSlebWDDL81N88Qf/SCAvRLR7F8ss=
 github.com/writefreely/go-nodeinfo v1.2.0/go.mod h1:UTvE78KpcjYOlRHupZIiSEFcXHioTXuacCbHU+CAcPg=
+github.com/xhit/go-simple-mail/v2 v2.16.0 h1:ouGy/Ww4kuaqu2E2UrDw7SvLaziWTB60ICLkIkNVccA=
+github.com/xhit/go-simple-mail/v2 v2.16.0/go.mod h1:b7P5ygho6SYE+VIqpxA6QkYfv4teeyG4MKqB3utRu98=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2024 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package mailer
+
+import (
+	"fmt"
+	"github.com/mailgun/mailgun-go"
+	"github.com/writefreely/writefreely/config"
+	mail "github.com/xhit/go-simple-mail/v2"
+)
+
+type (
+	// Mailer holds configurations for the preferred mailing provider.
+	Mailer struct {
+		smtp    *mail.SMTPServer
+		mailGun *mailgun.MailgunImpl
+	}
+
+	// Message holds the email contents and metadata for the preferred mailing provider.
+	Message struct {
+		mgMsg   *mailgun.Message
+		smtpMsg *mail.Email
+	}
+)
+
+// New creates a new Mailer from the instance's config.EmailCfg, returning an error if not properly configured.
+func New(eCfg *config.EmailCfg) (*Mailer, error) {
+	m := &Mailer{}
+	if eCfg.Domain != "" && eCfg.MailgunPrivate != "" {
+		m.mailGun = mailgun.NewMailgun(eCfg.Domain, eCfg.MailgunPrivate)
+	} else if eCfg.Username != "" && eCfg.Password != "" && eCfg.Host != "" && eCfg.Port > 0 {
+		m.smtp = mail.NewSMTPClient()
+		m.smtp.Host = eCfg.Host
+		m.smtp.Port = eCfg.Port
+		m.smtp.Username = eCfg.Username
+		m.smtp.Password = eCfg.Password
+		if eCfg.EnableStartTLS {
+			m.smtp.Encryption = mail.EncryptionSTARTTLS
+		}
+	} else {
+		return nil, fmt.Errorf("no email provider is configured")
+	}
+
+	return m, nil
+}
+
+// NewMessage creates a new Message from the given parameters.
+func (m *Mailer) NewMessage(from, subject, text string, to ...string) (*Message, error) {
+	msg := &Message{}
+	if m.mailGun != nil {
+		msg.mgMsg = m.mailGun.NewMessage(from, subject, text, to...)
+	} else if m.smtp != nil {
+		msg.smtpMsg = mail.NewMSG()
+		msg.smtpMsg.SetFrom(from)
+		msg.smtpMsg.AddTo(to...)
+		msg.smtpMsg.SetSubject(subject)
+		msg.smtpMsg.AddAlternative(mail.TextPlain, text)
+
+		if msg.smtpMsg.Error != nil {
+			return nil, msg.smtpMsg.Error
+		}
+	}
+	return msg, nil
+}
+
+// SetHTML sets the body of the message.
+func (m *Message) SetHTML(html string) {
+	if m.smtpMsg != nil {
+		m.smtpMsg.SetBody(mail.TextHTML, html)
+	} else if m.mgMsg != nil {
+		m.mgMsg.SetHtml(html)
+	}
+}
+
+// Send sends the given message via the preferred provider.
+func (m *Mailer) Send(msg *Message) error {
+	if m.smtp != nil {
+		client, err := m.smtp.Connect()
+		if err != nil {
+			return err
+		}
+		return msg.smtpMsg.Send(client)
+	} else if m.mailGun != nil {
+		_, _, err := m.mailGun.Send(msg.mgMsg)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -32,7 +32,7 @@ type (
 )
 
 // New creates a new Mailer from the instance's config.EmailCfg, returning an error if not properly configured.
-func New(eCfg *config.EmailCfg) (*Mailer, error) {
+func New(eCfg config.EmailCfg) (*Mailer, error) {
 	m := &Mailer{}
 	if eCfg.Domain != "" && eCfg.MailgunPrivate != "" {
 		m.mailGun = mailgun.NewMailgun(eCfg.Domain, eCfg.MailgunPrivate)
@@ -77,6 +77,13 @@ func (m *Message) SetHTML(html string) {
 		m.smtpMsg.SetBody(mail.TextHTML, html)
 	} else if m.mgMsg != nil {
 		m.mgMsg.SetHtml(html)
+	}
+}
+
+// AddTag attaches a tag to the Message for providers that support it.
+func (m *Message) AddTag(tag string) {
+	if m.mgMsg != nil {
+		m.mgMsg.AddTag(tag)
 	}
 }
 

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -12,11 +12,11 @@ package mailer
 
 import (
 	"fmt"
-	"strings"
 	"github.com/mailgun/mailgun-go"
-	"github.com/writefreely/writefreely/config"
 	"github.com/writeas/web-core/log"
+	"github.com/writefreely/writefreely/config"
 	mail "github.com/xhit/go-simple-mail/v2"
+	"strings"
 )
 
 type (
@@ -33,17 +33,17 @@ type (
 	}
 
 	SmtpMessage struct {
-		from string
-		replyTo string 
-		subject string
+		from       string
+		replyTo    string
+		subject    string
 		recipients []Recipient
-		html string
-		text string
+		html       string
+		text       string
 	}
 
 	Recipient struct {
 		email string
-		vars map[string]string
+		vars  map[string]string
 	}
 )
 
@@ -79,13 +79,13 @@ func (m *Mailer) NewMessage(from, subject, text string, to ...string) (*Message,
 	if m.mailGun != nil {
 		msg.mgMsg = m.mailGun.NewMessage(from, subject, text, to...)
 	} else if m.smtp != nil {
-		msg.smtpMsg = &SmtpMessage {
-			from,
-			"",
-			subject,
-			make([]Recipient, len(to)),
-			"",
-			text,
+		msg.smtpMsg = &SmtpMessage{
+			from:       from,
+			replyTo:    "",
+			subject:    subject,
+			recipients: make([]Recipient, len(to)),
+			html:       "",
+			text:       text,
 		}
 		for _, r := range to {
 			msg.smtpMsg.recipients = append(msg.smtpMsg.recipients, Recipient{r, make(map[string]string)})
@@ -104,7 +104,7 @@ func (m *Message) SetHTML(html string) {
 }
 
 func (m *Message) SetReplyTo(replyTo string) {
-	if (m.smtpMsg != nil) {
+	if m.smtpMsg != nil {
 		m.smtpMsg.replyTo = replyTo
 	} else {
 		m.mgMsg.SetReplyTo(replyTo)
@@ -142,7 +142,7 @@ func (m *Mailer) Send(msg *Message) error {
 		for _, r := range msg.smtpMsg.recipients {
 			customMsg := mail.NewMSG()
 			customMsg.SetFrom(msg.smtpMsg.from)
-			if (msg.smtpMsg.replyTo != "") {
+			if msg.smtpMsg.replyTo != "" {
 				customMsg.SetReplyTo(msg.smtpMsg.replyTo)
 			}
 			customMsg.SetSubject(msg.smtpMsg.subject)
@@ -163,7 +163,7 @@ func (m *Mailer) Send(msg *Message) error {
 			if e == nil {
 				emailSent = true
 			} else {
-				log.Error("Unable to send email to %s: %v",  r.email, e)
+				log.Error("Unable to send email to %s: %v", r.email, e)
 				err = e
 			}
 		}

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -36,6 +36,9 @@ func New(eCfg config.EmailCfg) (*Mailer, error) {
 	m := &Mailer{}
 	if eCfg.Domain != "" && eCfg.MailgunPrivate != "" {
 		m.mailGun = mailgun.NewMailgun(eCfg.Domain, eCfg.MailgunPrivate)
+		if eCfg.MailgunEurope {
+			m.mailGun.SetAPIBase("https://api.eu.mailgun.net/v3")
+		}
 	} else if eCfg.Username != "" && eCfg.Password != "" && eCfg.Host != "" && eCfg.Port > 0 {
 		m.smtp = mail.NewSMTPClient()
 		m.smtp.Host = eCfg.Host

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -83,10 +83,28 @@ func (m *Message) SetHTML(html string) {
 	}
 }
 
+func (m *Message) SetReplyTo(replyTo string) {
+	if (m.smtpMsg != nil) {
+		m.smtpMsg.SetReplyTo(replyTo)
+	} else {
+		m.mgMsg.SetReplyTo(replyTo)
+	}
+}
+
 // AddTag attaches a tag to the Message for providers that support it.
 func (m *Message) AddTag(tag string) {
 	if m.mgMsg != nil {
 		m.mgMsg.AddTag(tag)
+	}
+}
+
+// Variable only used by mailgun
+func (m *Message) AddRecipientAndVariables(r string, vars map[string]interface{}) error {
+	if (m.smtpMsg != nil) {
+		m.smtpMsg.AddBcc(r)
+		return nil
+	} else {
+		return m.mgMsg.AddRecipientAndVariables(r, vars)
 	}
 }
 
@@ -97,6 +115,7 @@ func (m *Mailer) Send(msg *Message) error {
 		if err != nil {
 			return err
 		}
+		// TODO: handle possible limits (new config?) on max recipients (multiple batches, with delay?)
 		return msg.smtpMsg.Send(client)
 	} else if m.mailGun != nil {
 		_, _, err := m.mailGun.Send(msg.mgMsg)

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -12,8 +12,10 @@ package mailer
 
 import (
 	"fmt"
+	"strings"
 	"github.com/mailgun/mailgun-go"
 	"github.com/writefreely/writefreely/config"
+	"github.com/writeas/web-core/log"
 	mail "github.com/xhit/go-simple-mail/v2"
 )
 
@@ -27,7 +29,21 @@ type (
 	// Message holds the email contents and metadata for the preferred mailing provider.
 	Message struct {
 		mgMsg   *mailgun.Message
-		smtpMsg *mail.Email
+		smtpMsg *SmtpMessage
+	}
+
+	SmtpMessage struct {
+		from string
+		replyTo string 
+		subject string
+		recipients []Recipient
+		html string
+		text string
+	}
+
+	Recipient struct {
+		email string
+		vars map[string]string
 	}
 )
 
@@ -48,6 +64,8 @@ func New(eCfg config.EmailCfg) (*Mailer, error) {
 		if eCfg.EnableStartTLS {
 			m.smtp.Encryption = mail.EncryptionSTARTTLS
 		}
+		// To allow sending multiple email
+		m.smtp.KeepAlive = true
 	} else {
 		return nil, fmt.Errorf("no email provider is configured")
 	}
@@ -61,14 +79,16 @@ func (m *Mailer) NewMessage(from, subject, text string, to ...string) (*Message,
 	if m.mailGun != nil {
 		msg.mgMsg = m.mailGun.NewMessage(from, subject, text, to...)
 	} else if m.smtp != nil {
-		msg.smtpMsg = mail.NewMSG()
-		msg.smtpMsg.SetFrom(from)
-		msg.smtpMsg.AddTo(to...)
-		msg.smtpMsg.SetSubject(subject)
-		msg.smtpMsg.AddAlternative(mail.TextPlain, text)
-
-		if msg.smtpMsg.Error != nil {
-			return nil, msg.smtpMsg.Error
+		msg.smtpMsg = &SmtpMessage {
+			from,
+			"",
+			subject,
+			make([]Recipient, len(to)),
+			"",
+			text,
+		}
+		for _, r := range to {
+			msg.smtpMsg.recipients = append(msg.smtpMsg.recipients, Recipient{r, make(map[string]string)})
 		}
 	}
 	return msg, nil
@@ -77,7 +97,7 @@ func (m *Mailer) NewMessage(from, subject, text string, to ...string) (*Message,
 // SetHTML sets the body of the message.
 func (m *Message) SetHTML(html string) {
 	if m.smtpMsg != nil {
-		m.smtpMsg.SetBody(mail.TextHTML, html)
+		m.smtpMsg.html = html
 	} else if m.mgMsg != nil {
 		m.mgMsg.SetHtml(html)
 	}
@@ -85,7 +105,7 @@ func (m *Message) SetHTML(html string) {
 
 func (m *Message) SetReplyTo(replyTo string) {
 	if (m.smtpMsg != nil) {
-		m.smtpMsg.SetReplyTo(replyTo)
+		m.smtpMsg.replyTo = replyTo
 	} else {
 		m.mgMsg.SetReplyTo(replyTo)
 	}
@@ -98,13 +118,16 @@ func (m *Message) AddTag(tag string) {
 	}
 }
 
-// Variable only used by mailgun
-func (m *Message) AddRecipientAndVariables(r string, vars map[string]interface{}) error {
-	if (m.smtpMsg != nil) {
-		m.smtpMsg.AddBcc(r)
+func (m *Message) AddRecipientAndVariables(r string, vars map[string]string) error {
+	if m.smtpMsg != nil {
+		m.smtpMsg.recipients = append(m.smtpMsg.recipients, Recipient{r, vars})
 		return nil
 	} else {
-		return m.mgMsg.AddRecipientAndVariables(r, vars)
+		varsInterfaces := make(map[string]interface{}, len(vars))
+		for k, v := range vars {
+			varsInterfaces[k] = v
+		}
+		return m.mgMsg.AddRecipientAndVariables(r, varsInterfaces)
 	}
 }
 
@@ -115,8 +138,39 @@ func (m *Mailer) Send(msg *Message) error {
 		if err != nil {
 			return err
 		}
-		// TODO: handle possible limits (new config?) on max recipients (multiple batches, with delay?)
-		return msg.smtpMsg.Send(client)
+		emailSent := false
+		for _, r := range msg.smtpMsg.recipients {
+			customMsg := mail.NewMSG()
+			customMsg.SetFrom(msg.smtpMsg.from)
+			if (msg.smtpMsg.replyTo != "") {
+				customMsg.SetReplyTo(msg.smtpMsg.replyTo)
+			}
+			customMsg.SetSubject(msg.smtpMsg.subject)
+			customMsg.AddTo(r.email)
+			cText := msg.smtpMsg.text
+			cHtml := msg.smtpMsg.html
+			for v, value := range r.vars {
+				placeHolder := fmt.Sprintf("%%recipient.%s%%", v)
+				cText = strings.ReplaceAll(cText, placeHolder, value)
+				cHtml = strings.ReplaceAll(cHtml, placeHolder, value)
+			}
+			customMsg.SetBody(mail.TextHTML, cHtml)
+			customMsg.AddAlternative(mail.TextPlain, cText)
+			e := customMsg.Error
+			if e == nil {
+				e = customMsg.Send(client)
+			}
+			if e == nil {
+				emailSent = true
+			} else {
+				log.Error("Unable to send email to %s: %v",  r.email, e)
+				err = e
+			}
+		}
+		if !emailSent {
+			// only send an error if no email could be sent (to avoid retry of successfully sent emails)
+			return err
+		}
 	} else if m.mailGun != nil {
 		_, _, err := m.mailGun.Send(msg.mgMsg)
 		if err != nil {

--- a/templates.go
+++ b/templates.go
@@ -14,8 +14,8 @@ import (
 	"errors"
 	"html/template"
 	"io"
-	"os"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 


### PR DESCRIPTION
This adds the ability to configure a bulk email provider via SMTP, instead of only supporting Mailgun.

**Work in progress**.

Closes [T905](https://todo.musing.studio/T905)

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
