### PR TITLE
Fix font toggle in classic editor #876

### DIFF
--- a/less/prose-editor.less
+++ b/less/prose-editor.less
@@ -33,6 +33,18 @@ body#pad.classic {
 	}
 }
 
+.norm {
+	font-family: serifFont;
+}
+
+.sans {
+	font-family: @sansFont;
+}
+
+.wrap {
+	font-family: @monoFont;
+}
+
 #title {
 	margin-left: @classicHorizMargin;
 	margin-right: @classicHorizMargin;

--- a/less/prose-editor.less
+++ b/less/prose-editor.less
@@ -34,7 +34,7 @@ body#pad.classic {
 }
 
 .norm {
-	font-family: serifFont;
+	font-family: @serifFont;
 }
 
 .sans {

--- a/prose/prose.js
+++ b/prose/prose.js
@@ -118,3 +118,4 @@ class ProseMirrorView {
 
 let place = document.querySelector("#editor");
 let view = new ProseMirrorView(place, $content.value);
+window.editorView = view;

--- a/templates/classic.tmpl
+++ b/templates/classic.tmpl
@@ -348,13 +348,27 @@
 		  } catch (e) {}
 		};
 		var fonts = document.querySelectorAll('nav#font-picker a.font');
+		var setFontClass = function(fontClass) {
+			return (state, dispatch) => {
+				if (dispatch && window.editorView) {
+					window.editorView.view.dom.classList.remove("norm", "sans", "wrap");
+					window.editorView.view.dom.classList.add(fontClass);
+				}
+				return true;
+			}
+		}
+		var changeEditorFont = function(fontClass) {
+			if (window.editorView) {
+				const command = setFontClass(fontClass);
+				command(window.editorView.view.state, window.editorView.view.dispatch);
+			}
+		};
 		for (var i=0; i<fonts.length; i++) {
 			fonts[i].addEventListener('click', function(e) {
 				e.preventDefault();
 				selectedFont = this.href.substring(this.href.indexOf('#')+1);
-				// TODO: don't change classes on the editor window
-				//$title.el.className = selectedFont;
-				//$writer.el.className = selectedFont;
+				$title.el.className = selectedFont;
+				changeEditorFont(selectedFont);
 				document.querySelector('nav#font-picker li.selected').classList.remove('selected');
 				this.parentElement.classList.add('selected');
 				H.set('{{if .Editing}}draft{{.Post.Id}}font{{else}}padFont{{end}}', selectedFont);
@@ -364,6 +378,7 @@
 			});
 		}
 		var selectedFont = H.get('{{if .Editing}}draft{{.Post.Id}}font{{else}}padFont{{end}}', '{{.Post.Font}}');
+		document.addEventListener('DOMContentLoaded', () => {changeEditorFont(selectedFont)});
 		var sfe = document.querySelector('nav#font-picker a.font.'+selectedFont);
 		if (sfe != null) {
 			sfe.click();

--- a/templates/classic.tmpl
+++ b/templates/classic.tmpl
@@ -348,19 +348,10 @@
 		  } catch (e) {}
 		};
 		var fonts = document.querySelectorAll('nav#font-picker a.font');
-		var setFontClass = function(fontClass) {
-			return (state, dispatch) => {
-				if (dispatch && window.editorView) {
-					window.editorView.view.dom.classList.remove("norm", "sans", "wrap");
-					window.editorView.view.dom.classList.add(fontClass);
-				}
-				return true;
-			}
-		}
-		var changeEditorFont = function(fontClass) {
+		var setEditorFontClass = function(fontClass) {
 			if (window.editorView) {
-				const command = setFontClass(fontClass);
-				command(window.editorView.view.state, window.editorView.view.dispatch);
+				window.editorView.view.dom.classList.remove("norm", "sans", "wrap");
+				window.editorView.view.dom.classList.add(fontClass);
 			}
 		};
 		for (var i=0; i<fonts.length; i++) {
@@ -368,7 +359,7 @@
 				e.preventDefault();
 				selectedFont = this.href.substring(this.href.indexOf('#')+1);
 				$title.el.className = selectedFont;
-				changeEditorFont(selectedFont);
+				setEditorFontClass(selectedFont);
 				document.querySelector('nav#font-picker li.selected').classList.remove('selected');
 				this.parentElement.classList.add('selected');
 				H.set('{{if .Editing}}draft{{.Post.Id}}font{{else}}padFont{{end}}', selectedFont);
@@ -378,7 +369,7 @@
 			});
 		}
 		var selectedFont = H.get('{{if .Editing}}draft{{.Post.Id}}font{{else}}padFont{{end}}', '{{.Post.Font}}');
-		document.addEventListener('DOMContentLoaded', () => {changeEditorFont(selectedFont)});
+		document.addEventListener('DOMContentLoaded', () => {setEditorFontClass(selectedFont)});
 		var sfe = document.querySelector('nav#font-picker a.font.'+selectedFont);
 		if (sfe != null) {
 			sfe.click();


### PR DESCRIPTION
### Description
This PR fixes the font toggle in the `classic` editor.

Original issue description: [Issue #876](https://github.com/writefreely/writefreely/issues/876).

### Changes Made
- in `prose.js`, i introduced a new window key called `editorView` and added the `ProseMirrorView` to it
- in `classic.tmpl`, i created a `setEditorFontClass` method to remove the previous font class and add the newly selected font
- in `classic.tmpl`, i added an event listener so when the editor loads for the first time, it grabs the currently selected font
- in `prose-editor.less`, i added the 3 different font classes (norm, sans, wrap) used in the tmpl files

### How to Test
1. Run `make ui` to apply css changes (depending on what version of node you have, you might need to run `NODE_OPTIONS=--openssl-legacy-provider make ui`) 
2. Set `editor=classic` in `config.ini`
3. Restart app
4. Go to Drafts
5. Click Edit
6. Toggle font to see if font in title and editor changes
7. Close draft and reopen editor to check if it uses the last selected font (try out sans serif or mono to be sure)

### Related Ticket
https://github.com/writefreely/writefreely/issues/876

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)