### PR TITLE
display stat numbers as monospace

### DIFF
--- a/templates/user/stats.tmpl
+++ b/templates/user/stats.tmpl
@@ -9,6 +9,7 @@ td + td {
 }
 td.num {
 	text-align: right;
+	font-family: Hack,consolas,Menlo-Regular,Menlo,Monaco,'ubuntu mono',monospace,monospace;
 }
 table.classy.export a { text-transform: inherit; }
 td.none {


### PR DESCRIPTION
this allows you to reliably compare the magnitude of numbers just by looking at their width.


before:
![image](https://github.com/user-attachments/assets/d7867760-f19e-4d30-8988-55e1899bc534)

after:
![image](https://github.com/user-attachments/assets/7150d54a-0f5f-472d-8b5a-21be01c9feb9)


---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
