### PR TITLE
email: allow sending emails from EU Mailgun domains

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -181,6 +181,7 @@ type (
 		// Mailgun configuration values
 		Domain         string `ini:"domain"`
 		MailgunPrivate string `ini:"mailgun_private"`
+		MailgunEurope  bool   `ini:"mailgun_europe"`
 	}
 
 	// Config holds the complete configuration for running a writefreely instance

--- a/email.go
+++ b/email.go
@@ -309,6 +309,12 @@ Originally published on ` + p.Collection.DisplayTitle() + ` (` + p.Collection.Ca
 Sent to %recipient.to%. Unsubscribe: ` + p.Collection.CanonicalURL() + `email/unsubscribe/%recipient.id%?t=%recipient.token%`
 
 	gun := mailgun.NewMailgun(app.cfg.Email.Domain, app.cfg.Email.MailgunPrivate)
+
+	if app.cfg.Email.MailgunEurope {
+		gun.SetAPIBase("https://api.eu.mailgun.net/v3")
+	}
+
+
 	m := mailgun.NewMessage(p.Collection.DisplayTitle()+" <"+p.Collection.Alias+"@"+app.cfg.Email.Domain+">", stripmd.Strip(p.DisplayTitle()), plainMsg)
 	replyTo := app.db.GetCollectionAttribute(collID, collAttrLetterReplyTo)
 	if replyTo != "" {

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -36,6 +36,9 @@ func New(eCfg config.EmailCfg) (*Mailer, error) {
 	m := &Mailer{}
 	if eCfg.Domain != "" && eCfg.MailgunPrivate != "" {
 		m.mailGun = mailgun.NewMailgun(eCfg.Domain, eCfg.MailgunPrivate)
+		if eCfg.MailgunEurope {
+			m.mailGun.SetAPIBase("https://api.eu.mailgun.net/v3")
+		}
 	} else if eCfg.Username != "" && eCfg.Password != "" && eCfg.Host != "" && eCfg.Port > 0 {
 		m.smtp = mail.NewSMTPClient()
 		m.smtp.Host = eCfg.Host


### PR DESCRIPTION
Closes https://github.com/writefreely/writefreely/issues/944 

From the commit:

```
The Mailgun API requires being told when a EU email domain is used[1] so introduce a new EU_MAILGUN environement variable to do just that.

[1]: https://github.com/mailgun/mailgun-go?tab=readme-ov-file#usage
```

I've never written Go so do provide guidance and let me know what else needs to be done. I'm going to write a bit of documentation shortly (in `writefreely/documentation`). Thanks!

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
