### PR TITLE
Do not show 'Draft' button when reading someone else's drafts

### DIFF
--- a/templates/post.tmpl
+++ b/templates/post.tmpl
@@ -41,10 +41,8 @@
 			<nav>
 				<span class="views{{if not .IsOwner}} owner-visible{{end}}" dir="ltr"><strong>{{largeNumFmt .Views}}</strong> {{pluralize "view" "views" .Views}}</span>
 				{{if .IsCode}}<a href="/{{.ID}}.txt" rel="noindex" dir="{{.Direction}}">View raw</a>{{end}}
-				{{ if .Username }}
-				{{if .IsOwner}}
+				{{ if and .Username .IsOwner }}
 				<a href="/{{if .SingleUser}}d/{{end}}{{.ID}}/edit" dir="{{.Direction}}">Edit</a>
-				{{end}}
 				<a class="xtra-feature dash-nav" href="/me/posts/" dir="{{.Direction}}">Drafts</a>
 				{{ end }}
 			</nav>


### PR DESCRIPTION
The button links to user's own draft box. Need not to be shown on other's draft posts.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
