### PR TITLE
Display fediverse:creator header tag on posts

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -971,6 +971,24 @@ func getRemoteUserFromHandle(app *App, handle string) (*RemoteUser, error) {
 	return &u, nil
 }
 
+// getRemoteUserFromURL retrieves the profile page of a remote user
+// from the @user@server.tld handle
+func getRemoteUserFromURL(app *App, urlStr string) (*RemoteUser, error) {
+	u := RemoteUser{URL: urlStr}
+	var urlVal, handle sql.NullString
+	err := app.db.QueryRow("SELECT id, actor_id, inbox, shared_inbox, url, handle FROM remoteusers WHERE url = ?", urlStr).Scan(&u.ID, &u.ActorID, &u.Inbox, &u.SharedInbox, &urlVal, &handle)
+	switch {
+	case err == sql.ErrNoRows:
+		return nil, ErrRemoteUserNotFound
+	case err != nil:
+		log.Error("Couldn't get remote user from URL %s: %v", urlStr, err)
+		return nil, err
+	}
+	u.URL = urlVal.String
+	u.Handle = handle.String
+	return &u, nil
+}
+
 func getActor(app *App, actorIRI string) (*activitystreams.Person, *RemoteUser, error) {
 	log.Info("Fetching actor %s locally", actorIRI)
 	actor := &activitystreams.Person{}

--- a/activitypub.go
+++ b/activitypub.go
@@ -971,8 +971,7 @@ func getRemoteUserFromHandle(app *App, handle string) (*RemoteUser, error) {
 	return &u, nil
 }
 
-// getRemoteUserFromURL retrieves the profile page of a remote user
-// from the @user@server.tld handle
+// getRemoteUserFromURL retrieves a RemoteUser from their public profile URL.
 func getRemoteUserFromURL(app *App, urlStr string) (*RemoteUser, error) {
 	u := RemoteUser{URL: urlStr}
 	var urlVal, handle sql.NullString

--- a/collections.go
+++ b/collections.go
@@ -630,18 +630,19 @@ func fetchCollectionPosts(app *App, w http.ResponseWriter, r *http.Request) erro
 type CollectionPage struct {
 	page.StaticPage
 	*DisplayCollection
-	IsCustomDomain bool
-	IsWelcome      bool
-	IsOwner        bool
-	IsCollLoggedIn bool
-	Honeypot       string
-	IsSubscriber   bool
-	CanPin         bool
-	Username       string
-	Monetization   string
-	Flash          template.HTML
-	Collections    *[]Collection
-	PinnedPosts    *[]PublicPost
+	IsCustomDomain  bool
+	IsWelcome       bool
+	IsOwner         bool
+	IsCollLoggedIn  bool
+	Honeypot        string
+	IsSubscriber    bool
+	CanPin          bool
+	Username        string
+	Monetization    string
+	FediverseAuthor string
+	Flash           template.HTML
+	Collections     *[]Collection
+	PinnedPosts     *[]PublicPost
 
 	IsAdmin   bool
 	CanInvite bool

--- a/posts.go
+++ b/posts.go
@@ -144,16 +144,17 @@ type (
 	CollectionPostPage struct {
 		*PublicPost
 		page.StaticPage
-		IsOwner        bool
-		IsPinned       bool
-		IsCustomDomain bool
-		Monetization   string
-		Verification   string
-		PinnedPosts    *[]PublicPost
-		IsFound        bool
-		IsAdmin        bool
-		CanInvite      bool
-		Silenced       bool
+		IsOwner         bool
+		IsPinned        bool
+		IsCustomDomain  bool
+		Monetization    string
+		Verification    string
+		FediverseAuthor string
+		PinnedPosts     *[]PublicPost
+		IsFound         bool
+		IsAdmin         bool
+		CanInvite       bool
+		Silenced        bool
 
 		// Helper field for Chorus mode
 		CollAlias string
@@ -1614,6 +1615,18 @@ Are you sure it was ever here?`,
 		tp.IsPinned = len(*tp.PinnedPosts) > 0 && PostsContains(tp.PinnedPosts, p)
 		tp.Monetization = coll.Monetization
 		tp.Verification = coll.Verification
+		if tp.Verification != "" {
+			// Fetch info for fediverse:creator tag
+			ru, err := getRemoteUserFromURL(app, coll.Verification)
+			if err != nil {
+				if debugging {
+					log.Info("showing rel=me tag, but no local handle for %s", coll.Verification)
+				}
+			} else {
+				// Though we don't store handles with leading @, strip it here just in case
+				tp.FediverseAuthor = "@" + strings.TrimLeft(ru.Handle, "@")
+			}
+		}
 
 		if !postFound {
 			w.WriteHeader(http.StatusNotFound)

--- a/templates/include/post-render.tmpl
+++ b/templates/include/post-render.tmpl
@@ -4,6 +4,7 @@
 		<meta name="monetization" content="{{.DisplayMonetization}}" />
 	{{- end}}
 	{{if .Verification -}}
+		{{if .FediverseAuthor}}<meta name="fediverse:creator" content="{{.FediverseAuthor}}">{{end}}
 		<link rel="me" href="{{.Verification}}" />
 	{{- end}}
 {{end}}


### PR DESCRIPTION
This uses the fediverse actor a blog author has added in the Verification field on their blog, looking up the handle locally (required by this tag, instead of the URL required for the `rel=me` tag) to display it in the `fediverse:creator` tag. If it doesn't exist locally, the tag is simply left out.

**Work in progress**, because ideally we'd always show the `fediverse:creator` tag. Right now, this will work if someone inputs their handle (e.g. `@matt@writing.exchange`) in the Verification field, because when saved, we fetch the remote user. We could solve this by _always_ fetching the remote user when updating the Verification value.

**Update**: see this comment: https://github.com/writefreely/writefreely/pull/1253#issuecomment-3221587222 and [T932](https://todo.musing.studio/T932) for remaining work.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
