### PR TITLE
Changed the permission of config file to allow access to only owner. …

### DIFF
--- a/app.go
+++ b/app.go
@@ -554,7 +554,7 @@ requests. We recommend supplying a valid host name.`)
 		}
 
 		if network == "unix" {
-			err = os.Chmod(bindAddress, 0o666)
+			err = os.Chmod(bindAddress, 0o600)
 			if err != nil {
 				log.Error("Could not update socket permissions: %v", err)
 				os.Exit(1)


### PR DESCRIPTION
Changed the permission of config file to allow access to only owner. This fixes CVE-2025-24337

Changed the permission of config file to allow access to only owner. This fixes CVE-2025-24337
---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
