### PR TITLE
Fix security context getting removed on AP collection endpoint

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -884,7 +884,6 @@ func handleViewCollection(app *App, w http.ResponseWriter, r *http.Request) erro
 	// Serve ActivityStreams data now, if requested
 	if IsActivityPubRequest(r) {
 		ac := c.PersonObject()
-		ac.Context = []interface{}{activitystreams.Namespace}
 		setCacheControl(w, apCacheTime)
 		return impart.RenderActivityJSON(w, ac, http.StatusOK)
 	}


### PR DESCRIPTION
Previously, we were overwriting the `context` property when fetching a collection as an ActivityPub object. This fixes that.

[Originally reported by @js@podcastindex.social](https://podcastindex.social/@js/113041934101924940)

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
