### PR TITLE
Fix Like counts on Stats page

### DIFF
--- a/database.go
+++ b/database.go
@@ -2075,6 +2075,12 @@ func (db *datastore) GetTopPosts(u *User, alias string, hostName string) (*[]Pub
 			c.hostName = hostName
 			pubPost.Collection = &CollectionObj{Collection: c}
 		}
+		p.LikeCount, err = db.GetPostLikeCounts(p.ID)
+		if err != nil {
+			log.Error("Failed GetPostLikeCounts(%s): %v", p.ID, err)
+			gotErr = true
+			break
+		}
 
 		posts = append(posts, pubPost)
 	}


### PR DESCRIPTION
This adds a missing query to populate each post with the number of likes it's received. Previously, this page would always show zero likes.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
