### PR TITLE
Use modern ICU regex syntax on MySQL 8+

### DIFF
--- a/app.go
+++ b/app.go
@@ -600,6 +600,18 @@ func ConnectToDatabase(app *App) error {
 	if err != nil {
 		return fmt.Errorf("Database ping failed: %s", err)
 	}
+	log.Info("Connected to database.")
+
+	ver, err := app.db.version()
+	if err != nil {
+		log.Error("Unable to get DB version: %v", err)
+	} else {
+		log.Info("Database version: %v", ver)
+		if app.cfg.Database.Type == driverMySQL && strings.HasPrefix(ver, "5.") {
+			log.Info("Enabling compatibility for MySQL v5.x")
+			app.db.isSpencerRegex = true
+		}
+	}
 
 	return nil
 }
@@ -859,7 +871,7 @@ func connectToDatabase(app *App) {
 		log.Error("%s", err)
 		os.Exit(1)
 	}
-	app.db = &datastore{db, app.cfg.Database.Type}
+	app.db = &datastore{DB: db, driverName: app.cfg.Database.Type}
 }
 
 func shutdown(app *App) {

--- a/app.go
+++ b/app.go
@@ -609,7 +609,7 @@ func ConnectToDatabase(app *App) error {
 		log.Info("Database version: %v", ver)
 		if app.cfg.Database.Type == driverMySQL && strings.HasPrefix(ver, "5.") {
 			log.Info("Enabling compatibility for MySQL v5.x")
-			app.db.isSpencerRegex = true
+			app.db.useSpencerRegex = true
 		}
 	}
 

--- a/database.go
+++ b/database.go
@@ -152,7 +152,7 @@ type datastore struct {
 	*sql.DB
 	driverName string
 
-	isSpencerRegex bool
+	useSpencerRegex bool
 }
 
 var _ writestore = &datastore{}
@@ -1448,7 +1448,7 @@ func (db *datastore) GetPostsTagged(cfg *config.Config, c *Collection, tag strin
 		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) regexp ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, `.*#`+strings.ToLower(tag)+`\b.*`)
 	} else {
 		var boundaryRegex string
-		if db.isSpencerRegex {
+		if db.useSpencerRegex {
 			// MySQL earlier than 8.0.4, Henry Spencer's regex implementation
 			boundaryRegex = "[[:>:]]"
 		} else {

--- a/database.go
+++ b/database.go
@@ -151,6 +151,8 @@ type writestore interface {
 type datastore struct {
 	*sql.DB
 	driverName string
+
+	isSpencerRegex bool
 }
 
 var _ writestore = &datastore{}
@@ -191,6 +193,20 @@ func (db *datastore) dateSub(l int, unit string) string {
 		return fmt.Sprintf("DATETIME('now', '-%d %s')", l, unit)
 	}
 	return fmt.Sprintf("DATE_SUB(NOW(), INTERVAL %d %s)", l, unit)
+}
+
+func (db *datastore) version() (string, error) {
+	var v string
+	var err error
+	if db.driverName == driverSQLite {
+		err = db.QueryRow("SELECT sqlite_version()").Scan(&v)
+	} else {
+		err = db.QueryRow("SELECT version()").Scan(&v)
+	}
+	if err != nil {
+		return "", err
+	}
+	return v, nil
 }
 
 // CreateUser creates a new user in the database from the given User, UPDATING it in the process with the user's ID.
@@ -1431,7 +1447,15 @@ func (db *datastore) GetPostsTagged(cfg *config.Config, c *Collection, tag strin
 	if db.driverName == driverSQLite {
 		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) regexp ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, `.*#`+strings.ToLower(tag)+`\b.*`)
 	} else {
-		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) RLIKE ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, "#"+strings.ToLower(tag)+"[[:>:]]")
+		var boundaryRegex string
+		if db.isSpencerRegex {
+			// MySQL earlier than 8.0.4, Henry Spencer's regex implementation
+			boundaryRegex = "[[:>:]]"
+		} else {
+			// MySQL 8.0.4+, International Components for Unicode (ICU) syntax
+			boundaryRegex = "\\b"
+		}
+		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) RLIKE ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, "#"+strings.ToLower(tag)+boundaryRegex)
 	}
 	if err != nil {
 		log.Error("Failed selecting from posts: %v", err)


### PR DESCRIPTION
This fixes the "illegal expression" error with MySQL v8.0.4+ when trying to fetch all posts with a particular hashtag in them, causing all hashtag pages to fail to load with a "page not found" error.

Now, we automatically detect the database version and use the correct syntax.

This also maintains backwards-compatibility with pre-8.0.4 versions of MySQL.

Fixes #615

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
