### PR TITLE
Use official WriteFreely docs for all help links

### DIFF
--- a/templates/chorus-collection.tmpl
+++ b/templates/chorus-collection.tmpl
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 
 		<title>{{.DisplayTitle}}{{if not .SingleUser}} &mdash; {{.SiteName}}{{end}}</title>
-		
+
 		<link rel="stylesheet" type="text/css" href="/css/write.css" />
 		{{if .CustomCSS}}<link rel="stylesheet" type="text/css" href="/local/custom.css" />{{end}}
 		<link rel="shortcut icon" href="/favicon.ico" />
@@ -62,7 +62,7 @@ body#collection header nav.tabs a:first-child {
 	</head>
 	<body id="collection" itemscope itemtype="http://schema.org/WebPage">
 		{{template "user-navigation" .}}
-		
+
 		{{if .Silenced}}
 			{{template "user-silenced"}}
 		{{end}}
@@ -76,7 +76,7 @@ body#collection header nav.tabs a:first-child {
 			{{range .PinnedPosts}}<a class="pinned" href="{{if not $.SingleUser}}/{{$.Alias}}/{{.Slug.String}}{{else}}{{.CanonicalURL $.Host}}{{end}}">{{.PlainDisplayTitle}}</a>{{end}}</nav>
 		{{end}}
 		</header>
-		
+
 		{{if .Posts}}<section id="wrapper" itemscope itemtype="http://schema.org/Blog">{{else}}<div id="wrapper">{{end}}
 
 			{{if .IsWelcome}}

--- a/templates/chorus-collection.tmpl
+++ b/templates/chorus-collection.tmpl
@@ -84,7 +84,7 @@ body#collection header nav.tabs a:first-child {
 				<h2>Welcome, <strong>{{.Username}}</strong>!</h2>
 				<p>This is your new blog.</p>
 				<p><a class="simple-cta" href="/#{{.Alias}}">Start writing</a>, or <a class="simple-cta" href="/me/c/{{.Alias}}">customize</a> your blog.</p>
-				<p>Check out our <a class="simple-cta" href="https://guides.write.as/writing/?pk_campaign=welcome">writing guide</a> to see what else you can do, and <a class="simple-cta" href="/contact">get in touch</a> anytime with questions or feedback.</p>
+				<p>Check out our <a class="simple-cta" href="https://writefreely.org/docs/latest/writer/writing">writing guide</a> to see what else you can do, and <a class="simple-cta" href="/contact">get in touch</a> anytime with questions or feedback.</p>
 			</div>
 			{{end}}
 

--- a/templates/collection.tmpl
+++ b/templates/collection.tmpl
@@ -100,7 +100,7 @@
 				<h2>Welcome, <strong>{{.Username}}</strong>!</h2>
 				<p>This is your new blog.</p>
 				<p><a class="simple-cta" href="/#{{.Alias}}">Start writing</a>, or <a class="simple-cta" href="/me/c/{{.Alias}}">customize</a> your blog.</p>
-				<p>Check out our <a class="simple-cta" href="https://guides.write.as/writing/?pk_campaign=welcome">writing guide</a> to see what else you can do, and <a class="simple-cta" href="/contact">get in touch</a> anytime with questions or feedback.</p>
+				<p>Check out our <a class="simple-cta" href="https://writefreely.org/docs/latest/writer/writing">writing guide</a> to see what else you can do, and <a class="simple-cta" href="/contact">get in touch</a> anytime with questions or feedback.</p>
 			</div>
 			{{end}}
 

--- a/templates/collection.tmpl
+++ b/templates/collection.tmpl
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 
 		<title>{{.DisplayTitle}}{{if not .SingleUser}} &mdash; {{.SiteName}}{{end}}</title>
-		
+
 		<link rel="stylesheet" type="text/css" href="/css/write.css" />
 		{{if .CustomCSS}}<link rel="stylesheet" type="text/css" href="/local/custom.css" />{{end}}
 		<link rel="shortcut icon" href="/favicon.ico" />
@@ -78,7 +78,7 @@
 				</li>
 			</ul></nav>
 		{{end}}
-		
+
 		<header>
 		{{if .Silenced}}
 			{{template "user-silenced"}}
@@ -92,7 +92,7 @@
 			{{range .PinnedPosts}}<a class="pinned" href="{{if not $.SingleUser}}/{{$.Alias}}/{{.Slug.String}}{{else}}{{.CanonicalURL $.Host}}{{end}}">{{.PlainDisplayTitle}}</a>{{end}}</nav>
 		{{end}}
 		</header>
-		
+
 		{{if .Posts}}<section id="wrapper" itemscope itemtype="http://schema.org/Blog">{{else}}<div id="wrapper">{{end}}
 
 			{{if .IsWelcome}}

--- a/templates/user/collection.tmpl
+++ b/templates/user/collection.tmpl
@@ -179,7 +179,7 @@ textarea.section.norm {
 		<h2>Custom CSS</h2>
 		<div class="section">
 			<textarea id="css-editor" class="section codable" name="style_sheet">{{.StyleSheet}}</textarea>
-			<p class="explain">See our guide on <a href="https://guides.write.as/customizing/#custom-css">customization</a>.</p>
+			<p class="explain">See our guide on <a href="https://writefreely.org/docs/latest/writer/css">customization</a>.</p>
 		</div>
 	</div>
 


### PR DESCRIPTION
This ensures users always go to consistent docs and not our very old site, guides.write.as.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
