### PR TITLE
Fix post signature showing up on blog's Post Not Found page

### DIFF
--- a/postrender.go
+++ b/postrender.go
@@ -99,7 +99,7 @@ func (p *Post) augmentContent(c *Collection) {
 		// Don't augment posts that are pinned
 		return
 	}
-	if strings.Index(p.Content, "<!--nosig-->") > -1 {
+	if strings.Index(p.Content, shortCodeNoSig) > -1 {
 		// Don't augment posts with the special "nosig" shortcode
 		return
 	}

--- a/posts.go
+++ b/posts.go
@@ -56,8 +56,9 @@ type PostType string
 const (
 	postArch PostType = "archive"
 
-	shortCodeMore = "<!--more-->"
-	shortCodePaid = "<!--paid-->"
+	shortCodeMore  = "<!--more-->"
+	shortCodePaid  = "<!--paid-->"
+	shortCodeNoSig = "<!--nosig-->"
 )
 
 type (
@@ -1565,7 +1566,7 @@ func viewCollectionPost(app *App, w http.ResponseWriter, r *http.Request) error 
 				RTL:      zero.NewBool(false, true),
 				Content: `<p class="msg">This page is missing.</p>
 
-Are you sure it was ever here?`,
+Are you sure it was ever here?` + shortCodeNoSig,
 			}
 			pp := po.processPost()
 			p = &pp


### PR DESCRIPTION
Previously, the signature would show up on Post Not Found pages, as we technically fake a Post behind the scenes to render this page. To fix, this simply inserts our special `<!--nosig-->` shortcode in the body of the post.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
