### PR TITLE
Ignore missing socket file on shutdown

### DIFF
--- a/app.go
+++ b/app.go
@@ -882,8 +882,13 @@ func shutdown(app *App) {
 		log.Info("Removing socket file...")
 		err := os.Remove(app.cfg.Server.Bind)
 		if err != nil {
-			log.Error("Unable to remove socket: %s", err)
-			os.Exit(1)
+			if os.IsNotExist(err) {
+				// Safely ignore, in cases like initializing / migrating DB (see #790)
+				log.Info("No socket file; ignoring...")
+			} else {
+				log.Error("Unable to remove socket: %s", err)
+				os.Exit(1)
+			}
 		}
 		log.Info("Success.")
 	}


### PR DESCRIPTION
This ensures no pointless errors come up when initializing or migrating the database while WriteFreely is configured to listen on a Unix socket.

Fixes #790

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
