### PR TITLE
Add missing `hostName` assignment in viewEditCollection

### DIFF
--- a/account.go
+++ b/account.go
@@ -862,6 +862,7 @@ func viewEditCollection(app *App, u *User, w http.ResponseWriter, r *http.Reques
 	if err != nil {
 		return err
 	}
+	c.hostName = app.cfg.App.Host
 	if c.OwnerID != u.ID {
 		return ErrCollectionNotFound
 	}

--- a/account.go
+++ b/account.go
@@ -13,8 +13,6 @@ package writefreely
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/writefreely/writefreely/mailer"
-	"github.com/writefreely/writefreely/spam"
 	"html/template"
 	"net/http"
 	"regexp"
@@ -33,7 +31,9 @@ import (
 	"github.com/writeas/web-core/log"
 	"github.com/writefreely/writefreely/author"
 	"github.com/writefreely/writefreely/config"
+	"github.com/writefreely/writefreely/mailer"
 	"github.com/writefreely/writefreely/page"
+	"github.com/writefreely/writefreely/spam"
 )
 
 type (


### PR DESCRIPTION
This fixes #907, where a false error log would appear.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
