### PR TITLE
Fix collection Customize page header nav on single-user instances

### DIFF
--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -16,9 +16,9 @@
 					</ul>
 				</nav>
 				<nav class="tabs">
-					<a href="/me/c/{{.Username}}" {{if and (hasPrefix .Path "/me/c/") (hasSuffix .Path .Username)}}class="selected"{{end}}>Customize</a>
-					<a href="/me/c/{{.Username}}/stats" {{if hasSuffix .Path "/stats"}}class="selected"{{end}}>Stats</a>
-					<a href="/me/c/{{.Username}}/subscribers" {{if hasSuffix .Path "/subscribers"}}class="selected"{{end}}>Subscribers</a>
+					<a href="/me/c/{{.UserPage.Username}}" {{if and (hasPrefix .Path "/me/c/") (hasSuffix .Path .UserPage.Username)}}class="selected"{{end}}>Customize</a>
+					<a href="/me/c/{{.UserPage.Username}}/stats" {{if hasSuffix .Path "/stats"}}class="selected"{{end}}>Stats</a>
+					<a href="/me/c/{{.UserPage.Username}}/subscribers" {{if hasSuffix .Path "/subscribers"}}class="selected"{{end}}>Subscribers</a>
 					<a href="/me/posts/"{{if eq .Path "/me/posts/"}} class="selected"{{end}}>Drafts</a>
 				</nav>
 			</nav>


### PR DESCRIPTION
Previously, the username was blank, messing up the URL of other nav bar links. Likely introduced by SMTP email support changes.

Fixes #1486

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
