### PR TITLE
Fix single-user blog URL on Customize page

### DIFF
--- a/templates/user/collection.tmpl
+++ b/templates/user/collection.tmpl
@@ -46,7 +46,7 @@ textarea.section.norm {
 			{{if eq .Alias .Username}}<p style="font-size: 0.8em">This blog uses your username in its URL{{if .Federation}} and fediverse handle{{end}}. You can change it in your <a href="/me/settings">Account Settings</a>.</p>{{end}}
 			<ul style="list-style:none">
 				<li>
-					{{.FriendlyHost}}/<strong>{{.Alias}}</strong>/
+					{{.FriendlyHost}}/{{if not .SingleUser}}<strong>{{.Alias}}</strong>/{{end}}
 				</li>
 				<li>
 					<strong id="normal-handle-env" class="fedi-handle" {{if not .Federation}}style="display:none"{{end}}>@<span id="fedi-handle">{{.Alias}}</span>@<span id="fedi-domain">{{.FriendlyHost}}</span></strong>


### PR DESCRIPTION
Previously, the Customize page showed the wrong URL for single-user blogs, which should always show the top-level address.

Fixes #1390

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
