### PR TITLE
Redirect /read/feed to correct /read/feed/ URL

### DIFF
--- a/read.go
+++ b/read.go
@@ -294,7 +294,7 @@ func viewLocalTimelineFeed(app *App, w http.ResponseWriter, req *http.Request) e
 		return impart.HTTPError{http.StatusNotFound, "Page doesn't exist."}
 	}
 	if !strings.HasSuffix(req.URL.Path, "/") {
-		return impart.HTTPError{http.StatusFound, "/read/feed/"}
+		return impart.HTTPError{http.StatusMovedPermanently, "/read/feed/"}
 	}
 
 	updateTimelineCache(app.timeline, false)

--- a/read.go
+++ b/read.go
@@ -17,6 +17,7 @@ import (
 	"math"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/gorilla/feeds"
@@ -291,6 +292,9 @@ func handlePostIDRedirect(app *App, w http.ResponseWriter, r *http.Request) erro
 func viewLocalTimelineFeed(app *App, w http.ResponseWriter, req *http.Request) error {
 	if !app.cfg.App.LocalTimeline {
 		return impart.HTTPError{http.StatusNotFound, "Page doesn't exist."}
+	}
+	if !strings.HasSuffix(req.URL.Path, "/") {
+		return impart.HTTPError{http.StatusFound, "/read/feed/"}
 	}
 
 	updateTimelineCache(app.timeline, false)

--- a/routes.go
+++ b/routes.go
@@ -242,6 +242,7 @@ func RouteCollections(handler *Handler, r *mux.Router) {
 func RouteRead(handler *Handler, readPerm UserLevelFunc, r *mux.Router) {
 	r.HandleFunc("/api/posts", handler.Web(viewLocalTimelineAPI, readPerm))
 	r.HandleFunc("/p/{page}", handler.Web(viewLocalTimeline, readPerm))
+	r.HandleFunc("/feed", handler.Web(viewLocalTimelineFeed, readPerm))
 	r.HandleFunc("/feed/", handler.Web(viewLocalTimelineFeed, readPerm))
 	r.HandleFunc("/t/{tag}", handler.Web(viewLocalTimeline, readPerm))
 	r.HandleFunc("/a/{post}", handler.Web(handlePostIDRedirect, readPerm))


### PR DESCRIPTION
The Reader's RSS feed is only served from the URL with the trailing slash.

This fixes an issue originally shared [on the forum](https://discuss.write.as/t/people-kernel-org-redirect-read-feed-to-read-feed/19939).

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
