### PR TITLE
Add support for alternative smallweb URL schemes

### DIFF
--- a/postrender.go
+++ b/postrender.go
@@ -272,7 +272,7 @@ func getSanitizationPolicy() *bluemonday.Policy {
 	policy.AllowAttrs("style", "class", "id").Globally()
 	policy.AllowAttrs("alt").OnElements("img")
 	policy.AllowElements("header", "footer")
-	policy.AllowURLSchemes("http", "https", "mailto", "xmpp")
+	policy.AllowURLSchemes("http", "https", "mailto", "xmpp", "gopher", "gophers", "gemini", "spartan")
 	return policy
 }
 


### PR DESCRIPTION
Adds `gopher://`, `gophers://`, `gemini://`, and `spartan://` protocols to the sanitization policy to allow these alternative protocol links in markdown content.

Fixes #1557

This PR adds support for rendering alternative smallweb protocol links in markdown content. Previously, links using these protocols were being stripped from markdown content. This change allows these alternative protocols to be rendered as proper HTML links, similar to the existing support for http, https, mailto, and xmpp.

Protocols added:
- `gopher://`
- `gophers://`
- `gemini://`
- `spartan://`
The change modifies `getSanitizationPolicy()` in `postrender.go` to include these protocols in the list of allowed URL schemes.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)