### PR TITLE
Fix character set for post signature column on MySQL / MariaDB instances

### DIFF
--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -56,22 +56,23 @@ func (m *migration) Migrate(db *datastore) error {
 }
 
 var migrations = []Migration{
-	New("support user invites", supportUserInvites),                 // -> V1 (v0.8.0)
-	New("support dynamic instance pages", supportInstancePages),     // V1 -> V2 (v0.9.0)
-	New("support users suspension", supportUserStatus),              // V2 -> V3 (v0.11.0)
-	New("support oauth", oauth),                                     // V3 -> V4
-	New("support slack oauth", oauthSlack),                          // V4 -> v5
-	New("support ActivityPub mentions", supportActivityPubMentions), // V5 -> V6
-	New("support oauth attach", oauthAttach),                        // V6 -> V7
-	New("support oauth via invite", oauthInvites),                   // V7 -> V8 (v0.12.0)
-	New("optimize drafts retrieval", optimizeDrafts),                // V8 -> V9
-	New("support post signatures", supportPostSignatures),           // V9 -> V10 (v0.13.0)
-	New("Widen oauth_users.access_token", widenOauthAcceesToken),    // V10 -> V11
-	New("support verifying fedi profile", fediverseVerifyProfile),   // V11 -> V12 (v0.14.0)
-	New("support newsletters", supportLetters),                      // V12 -> V13
-	New("support password resetting", supportPassReset),             // V13 -> V14
-	New("speed up blog post retrieval", addPostRetrievalIndex),      // V14 -> V15
-	New("support ActivityPub likes", supportRemoteLikes),            // V15 -> V16 (v0.16.0)
+	New("support user invites", supportUserInvites),                  // -> V1 (v0.8.0)
+	New("support dynamic instance pages", supportInstancePages),      // V1 -> V2 (v0.9.0)
+	New("support users suspension", supportUserStatus),               // V2 -> V3 (v0.11.0)
+	New("support oauth", oauth),                                      // V3 -> V4
+	New("support slack oauth", oauthSlack),                           // V4 -> v5
+	New("support ActivityPub mentions", supportActivityPubMentions),  // V5 -> V6
+	New("support oauth attach", oauthAttach),                         // V6 -> V7
+	New("support oauth via invite", oauthInvites),                    // V7 -> V8 (v0.12.0)
+	New("optimize drafts retrieval", optimizeDrafts),                 // V8 -> V9
+	New("support post signatures", supportPostSignatures),            // V9 -> V10 (v0.13.0)
+	New("Widen oauth_users.access_token", widenOauthAcceesToken),     // V10 -> V11
+	New("support verifying fedi profile", fediverseVerifyProfile),    // V11 -> V12 (v0.14.0)
+	New("support newsletters", supportLetters),                       // V12 -> V13
+	New("support password resetting", supportPassReset),              // V13 -> V14
+	New("speed up blog post retrieval", addPostRetrievalIndex),       // V14 -> V15
+	New("support ActivityPub likes", supportRemoteLikes),             // V15 -> V16 (v0.16.0)
+	New("fix post signature character set", fixPostSignatureCharset), // V16 -> V17 (v0.17.0)
 }
 
 // CurrentVer returns the current migration version the application is on

--- a/migrations/v17.go
+++ b/migrations/v17.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2026 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package migrations
+
+func fixPostSignatureCharset(db *datastore) error {
+	// Only run this migration on MySQL databases
+	if db.driverName != driverMySQL {
+		return nil
+	}
+
+	t, err := db.Begin()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	_, err = t.Exec(`ALTER TABLE collections MODIFY post_signature TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;`)
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	err = t.Commit()
+	if err != nil {
+		t.Rollback()
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Previously, we never specified the character set, and it seemed to default to `utf8mb3` instead of `utf8mb4`, which caused issues when updating the value if, for example, the signature contained emoji.

Fixes #1572

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
