### PR TITLE
Support changing published post font on web

### DIFF
--- a/less/core.less
+++ b/less/core.less
@@ -537,7 +537,7 @@ textarea, input#title, pre, body#post article, body#collection article p {
 		word-wrap: break-word;       /* Internet Explorer 5.5+ */
 	}
 }
-textarea, input#title, pre, body#post article, body#collection article, body#subpage article, span, .font {
+textarea, input#title, pre, body#post article, body#collection article, body#subpage article, span, .font, option {
 	&.norm {
 		font-family: @serifFont;
 	}

--- a/templates/edit-meta.tmpl
+++ b/templates/edit-meta.tmpl
@@ -261,6 +261,16 @@
 						<input type="text" id="created" name="created" value="{{.Post.UserFacingCreated}}" data-time="{{.Post.Created8601}}" placeholder="YYYY-MM-DD HH:MM:SS" maxlength="19" /> <span id="tz">UTC</span> <a href="#" id="set-now">now</a>
 						<p class="error" id="create-error">Date format should be: <span class="mono"><abbr title="The full year">YYYY</abbr>-<abbr title="The numeric month of the year, where January = 1, with a zero in front if less than 10">MM</abbr>-<abbr title="The day of the month, with a zero in front if less than 10">DD</abbr> <abbr title="The hour (00-23), with a zero in front if less than 10.">HH</abbr>:<abbr title="The minute of the hour (00-59), with a zero in front if less than 10.">MM</abbr>:<abbr title="The seconds (00-59), with a zero in front if less than 10.">SS</abbr></span></p>
 					</dd>
+                    <dt><label for="lang">Font</label></dt>
+                    <dd>
+                        <select name="font" id="font" dir="auto" class="inputform">
+                            <option value="norm" {{if eq .Post.Font "norm"}}selected="selected"{{end}}>Serif</option>
+                            <option class="sans" value="sans" {{if eq .Post.Font "sans"}}selected="selected"{{end}}>Sans-Serif</option>
+                            <option class="mono" value="wrap" {{if eq .Post.Font "wrap"}}selected="selected"{{end}}>Monospace</option>
+                            <option class="mono" value="mono" {{if eq .Post.Font "mono"}}selected="selected"{{end}}>No-wrap Monospace</option>
+                            <option class="mono" value="code" {{if eq .Post.Font "code"}}selected="selected"{{end}}>Code</option>
+                        </select>
+                    </dd>
 					<dt>&nbsp;</dt><dd><input type="submit" value="Save changes" /></dd>
 				</dl>
 				<input type="hidden" name="web" value="true" />

--- a/templates/edit-meta.tmpl
+++ b/templates/edit-meta.tmpl
@@ -3,7 +3,7 @@
 	<head>
 
 		<title>Edit metadata: {{if .Post.Title}}{{.Post.Title}}{{else}}{{.Post.Id}}{{end}} &mdash; {{.SiteName}}</title>
-		
+
 		<link rel="stylesheet" type="text/css" href="/css/write.css" />
 		{{if .CustomCSS}}<link rel="stylesheet" type="text/css" href="/local/custom.css" />{{end}}
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -36,7 +36,7 @@
 
 	</head>
 	<body id="pad-sub" class="light">
-		
+
 		<header id="tools">
 			<div id="clip">
 				<h1><a href="/me/c/" title="View blogs"><img class="ic-24dp" src="/img/ic_blogs_dark@2x.png" /></a></h1>
@@ -50,7 +50,7 @@
 				<div class="tool if-room room-1"><a href="/me/posts/" title="View posts" id="view-posts"><img class="ic-24dp" src="/img/ic_list_dark@2x.png" /></a></div>
 			</div>
 		</header>
-		
+
 		<div class="content-container tight">
 			<form action="/api/{{if .EditCollection}}collections/{{.EditCollection.Alias}}/{{end}}posts/{{.Post.Id}}" method="post" onsubmit="return updateMeta()">
 				<h2>Edit metadata: {{if .Post.Title}}{{.Post.Title}}{{else}}{{.Post.Id}}{{end}} <a href="/{{if .EditCollection}}{{if not .SingleUser}}{{.EditCollection.Alias}}/{{end}}{{.Post.Slug}}{{else}}{{if .SingleUser}}d/{{end}}{{.Post.Id}}{{end}}">view post</a></h2>
@@ -276,7 +276,7 @@
 				<input type="hidden" name="web" value="true" />
 			</form>
 		</div>
-		
+
 		<script src="/js/h.js"></script>
 		<script>
 function updateMeta() {


### PR DESCRIPTION
This supports changing the font of an existing post from the Post Metadata page.

This includes CSS changes. To see those, run:

```
make ui
```

Ref [T937](https://writefreely.org/tasks/937)

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
