### PR TITLE
Sort list of Fediverse followers by subscription date, descending

### DIFF
--- a/database.go
+++ b/database.go
@@ -1555,7 +1555,12 @@ ORDER BY created `+order+limitStr, collID, lang)
 }
 
 func (db *datastore) GetAPFollowers(c *Collection) (*[]RemoteUser, error) {
-	rows, err := db.Query("SELECT actor_id, inbox, shared_inbox, f.created FROM remotefollows f INNER JOIN remoteusers u ON f.remote_user_id = u.id WHERE collection_id = ?", c.ID)
+	rows, err := db.Query(`SELECT actor_id, inbox, shared_inbox, f.created
+FROM remotefollows f
+INNER JOIN remoteusers u
+  ON f.remote_user_id = u.id
+WHERE collection_id = ?
+ORDER BY created DESC`, c.ID)
 	if err != nil {
 		log.Error("Failed selecting from followers: %v", err)
 		return nil, impart.HTTPError{http.StatusInternalServerError, "Couldn't retrieve followers."}


### PR DESCRIPTION
This fixes an issue where the Subscribers list could show everyone in an arbitrary order. It also changes formatting of the query to make it a little easier to read.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
