### PR TITLE
Add global light / dark theme toggle

### DIFF
--- a/less/pad-theme.less
+++ b/less/pad-theme.less
@@ -215,3 +215,154 @@ body {
 		}
 	}
 }
+
+html {
+	&.light {
+		body:not(#pad):not(#pad-sub) {
+			background-color: @lightBG;
+			color: @lightTextColor;
+		}
+	}
+
+	&.dark {
+		body:not(#pad):not(#pad-sub) {
+			background-color: @darkBG;
+			color: @darkTextColor;
+		}
+
+		body:not(#pad):not(#pad-sub) {
+			a {
+				color: @darkLinkColor;
+				&:hover {
+					color: darken(@darkLinkColor, 10%);
+				}
+			}
+
+			h1, h2, h3, h4, h5, h6 {
+				color: @darkTextColor;
+				a {
+					color: @darkTextColor;
+				}
+			}
+
+			hr {
+				background: @darkNavBorder;
+			}
+
+			footer nav,
+			.description,
+			.meta-note,
+			.subtitle,
+			.post-title time,
+			.post-title time a:link,
+			.post-title time a:visited,
+			.post-title + .time {
+				color: #999;
+			}
+
+			input, textarea, select {
+				background: @darkNavBG;
+				color: @darkTextColor;
+				border-color: @darkNavBorder;
+			}
+
+			pre, code, blockquote {
+				background-color: #262626;
+				color: @darkTextColor;
+				border-color: @darkNavBorder;
+			}
+
+			.dropdown-nav ul ul,
+			nav#manage ul ul {
+				background: @darkNavBG;
+				border-color: @darkNavBorder;
+			}
+
+			.dropdown-nav ul li,
+			nav#manage ul li {
+				&:hover {
+					background: @darkNavHoverBG;
+				}
+				&.current-user {
+					color: #fff;
+				}
+				&.menu-heading {
+					color: #ccc;
+				}
+				&.selected {
+					a {
+						color: #777;
+					}
+				}
+			}
+
+			.dropdown-nav ul a,
+			nav#manage ul a,
+			header nav a,
+			#user-nav a,
+			#full-nav a {
+				color: @darkTextColor;
+			}
+
+			nav#full-nav a.simple-btn {
+				background: @darkNavBG;
+				color: @darkTextColor;
+				border-color: @darkNavBorder !important;
+			}
+
+			img.ic-18dp,
+			img.ic-24dp {
+				filter: brightness(1.15);
+			}
+
+			.alert {
+				&.info {
+					color: #b9def0;
+					background-color: #24404d;
+					border-color: #35596a;
+				}
+				&.success {
+					color: #cde9c7;
+					background-color: #294232;
+					border-color: #3a6047;
+				}
+				&.danger {
+					color: #f4d999;
+					background-color: #473c1d;
+					border-color: #856404;
+					h3 {
+						color: @darkTextColor !important;
+					}
+				}
+			}
+		}
+	}
+}
+
+.global-theme-toggle {
+	display: inline-block;
+	position: relative;
+	top: -0.15rem;
+	margin-right: 0.85rem;
+	padding: 0;
+	background: transparent;
+	border: 0;
+	box-shadow: none;
+	line-height: 1;
+	vertical-align: middle;
+	&:hover {
+		text-decoration: none;
+	}
+	img {
+		display: block;
+		filter: none !important;
+	}
+}
+
+.global-theme-toggle--floating {
+	position: fixed;
+	top: 1.15rem;
+	right: 1.25rem;
+	z-index: 1000;
+	margin-left: 0;
+}

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,93 @@
+(function () {
+  var STORAGE_KEY = "padTheme";
+  var LIGHT = "light";
+  var DARK = "dark";
+
+  function preferredTheme() {
+    return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? DARK : LIGHT;
+  }
+
+  function storedTheme() {
+    try {
+      return localStorage.getItem(STORAGE_KEY);
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function currentTheme() {
+    return storedTheme() || preferredTheme();
+  }
+
+  function setTheme(theme) {
+    var next = theme === DARK ? DARK : LIGHT;
+    document.documentElement.classList.remove(LIGHT, DARK);
+    document.documentElement.classList.add(next);
+    if (document.body) {
+      document.body.classList.remove(LIGHT, DARK);
+      document.body.classList.add(next);
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch (e) {
+      // ignore storage errors
+    }
+    updateThemeIcons(next);
+  }
+
+  function toggleTheme() {
+    setTheme(document.documentElement.classList.contains(DARK) ? LIGHT : DARK);
+  }
+
+  function updateThemeIcons(theme) {
+    var btns = document.querySelectorAll('#tools a img, [data-theme-toggle] img');
+    for (var i = 0; i < btns.length; i++) {
+      var img = btns[i];
+      if (!img.src) {
+        continue;
+      }
+      if (/ic_brightness(_dark)?@2x\.png$/.test(img.src)) {
+        img.src = theme === LIGHT
+          ? img.src.replace(/ic_brightness(_dark)?@2x\.png$/, 'ic_brightness_dark@2x.png')
+          : img.src.replace(/ic_brightness(_dark)?@2x\.png$/, 'ic_brightness@2x.png');
+        continue;
+      }
+      if (theme === LIGHT) {
+        if (!/_dark@2x\.png$/.test(img.src)) {
+          img.src = img.src.replace(/@2x\.png$/, '_dark@2x.png');
+        }
+      } else {
+        img.src = img.src.replace(/_dark@2x\.png$/, '@2x.png');
+      }
+    }
+  }
+
+  function bindToggle(el) {
+    if (!el || el.dataset.themeBound === "true") {
+      return;
+    }
+    el.dataset.themeBound = "true";
+    el.addEventListener("click", function (e) {
+      e.preventDefault();
+      toggleTheme();
+    });
+  }
+
+  function init() {
+    setTheme(currentTheme());
+    bindToggle(document.getElementById("toggle-theme"));
+    var more = document.querySelectorAll("[data-theme-toggle]");
+    for (var i = 0; i < more.length; i++) {
+      bindToggle(more[i]);
+    }
+  }
+
+  window.toggleTheme = toggleTheme;
+  window.setTheme = setTheme;
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -1,7 +1,17 @@
 {{define "base"}}<!DOCTYPE HTML>
-<html>
+<html class="light">
 	<head>
 		{{ template "head" . }}
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 		<link rel="stylesheet" type="text/css" href="/css/{{.Theme}}.css" />
 		{{if .CustomCSS}}<link rel="stylesheet" type="text/css" href="/local/custom.css" />{{end}}
 		<link rel="shortcut icon" href="/favicon.ico" />
@@ -69,6 +79,7 @@
 		{{ template "footer" . }}
 		
 		{{if not .JSDisabled}}
+		<script type="text/javascript" src="/js/theme.js"></script>
 		<script type="text/javascript" src="/js/menu.js"></script>
 		<script type="text/javascript">
 		{{if .WebFonts}}

--- a/templates/chorus-collection-post.tmpl
+++ b/templates/chorus-collection-post.tmpl
@@ -1,7 +1,17 @@
 {{define "post"}}<!DOCTYPE HTML>
-<html {{if .Language.Valid}}lang="{{.Language.String}}"{{end}} dir="{{.Direction}}">
+<html class="light" {{if .Language.Valid}}lang="{{.Language.String}}"{{end}} dir="{{.Direction}}">
 	<head prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article#">
 		<meta charset="utf-8">
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 
 		<title>{{.PlainDisplayTitle}} {{localhtml "title dash" .Language.String}} {{.Collection.DisplayTitle}}</title>
 		
@@ -143,6 +153,8 @@ function unpinPost(e, postID) {
 	  })();
 	} catch (e) { /* ¯\_(ツ)_/¯ */ }
 	</script>
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
+	<script src="/js/theme.js"></script>
 
     {{if and .Monetization (not .IsOwner)}}
 		<script src="/js/webmonetization.js"></script>

--- a/templates/chorus-collection.tmpl
+++ b/templates/chorus-collection.tmpl
@@ -1,7 +1,17 @@
 {{define "collection"}}<!DOCTYPE HTML>
-<html {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
+<html class="light" {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
 	<head>
 		<meta charset="utf-8">
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 
 		<title>{{.DisplayTitle}}{{if not .SingleUser}} &mdash; {{.SiteName}}{{end}}</title>
 
@@ -233,4 +243,6 @@ function pinPost(e, postID, slug, title) {
 	  })();
 	} catch (e) {}
 	</script>
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
+	<script src="/js/theme.js"></script>
 </html>{{end}}

--- a/templates/collection-archive.tmpl
+++ b/templates/collection-archive.tmpl
@@ -1,7 +1,17 @@
 {{define "collection"}}<!DOCTYPE HTML>
-<html>
+<html class="light">
 <head prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article#">
 	<meta charset="utf-8">
+	<script type="text/javascript">
+		(function () {
+			var theme = localStorage.getItem('padTheme');
+			if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+				theme = 'dark';
+			}
+			document.documentElement.classList.remove('light', 'dark');
+			document.documentElement.classList.add(theme || 'light');
+		})();
+	</script>
 
 	<title>Archive &mdash; {{.Collection.DisplayTitle}}</title>
 
@@ -107,6 +117,7 @@
 			</nav>
 		</footer>
 	{{ end }}
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
 
 </body>
 
@@ -115,4 +126,5 @@
     {{if .Collection.Script}}<script type="text/javascript">{{.ScriptDisplay}}</script>{{end}}
 {{end}}
 <script src="/js/localdate.js"></script>
+<script src="/js/theme.js"></script>
 </html>{{end}}

--- a/templates/collection-post.tmpl
+++ b/templates/collection-post.tmpl
@@ -1,7 +1,17 @@
 {{define "post"}}<!DOCTYPE HTML>
-<html {{if .Language.Valid}}lang="{{.Language.String}}"{{end}} dir="{{.Direction}}">
+<html class="light" {{if .Language.Valid}}lang="{{.Language.String}}"{{end}} dir="{{.Direction}}">
 	<head prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article#">
 		<meta charset="utf-8">
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 
 		<title>{{.PlainDisplayTitle}} {{localhtml "title dash" .Language.String}} {{.Collection.DisplayTitle}}</title>
 
@@ -134,6 +144,8 @@ function unpinPost(e, postID) {
 	  })();
 	} catch (e) { /* ¯\_(ツ)_/¯ */ }
 	</script>
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
+	<script src="/js/theme.js"></script>
 
     {{if and .Monetization (not .IsOwner)}}
 		<script src="/js/webmonetization.js"></script>

--- a/templates/collection-tags.tmpl
+++ b/templates/collection-tags.tmpl
@@ -1,7 +1,17 @@
 {{define "collection-tags"}}<!DOCTYPE HTML>
-<html>
+<html class="light">
 	<head prefix="og: http://ogp.me/ns# article: http://ogp.me/ns/article#">
 		<meta charset="utf-8">
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 
 		<title>{{.Tag}} &mdash; {{.Collection.DisplayTitle}}</title>
 		
@@ -208,4 +218,6 @@ function pinPost(e, postID, slug, title) {
 	  })();
 	} catch (e) { /* ¯\_(ツ)_/¯ */ }
 	</script>
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
+	<script src="/js/theme.js"></script>
 </html>{{end}}

--- a/templates/collection.tmpl
+++ b/templates/collection.tmpl
@@ -1,7 +1,17 @@
 {{define "collection"}}<!DOCTYPE HTML>
-<html {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
+<html class="light" {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
 	<head>
 		<meta charset="utf-8">
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 
 		<title>{{.DisplayTitle}}{{if not .SingleUser}} &mdash; {{.SiteName}}{{end}}</title>
 
@@ -258,4 +268,6 @@ function pinPost(e, postID, slug, title) {
 	  })();
 	} catch (e) {}
 	</script>
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
+	<script src="/js/theme.js"></script>
 </html>{{end}}

--- a/templates/edit-meta.tmpl
+++ b/templates/edit-meta.tmpl
@@ -29,6 +29,16 @@
 		.content-container h2 a:link, .content-container h2 a:visited {
 			color: blue;
 		}
+		html.dark .content-container h2 a:link,
+		html.dark .content-container h2 a:visited,
+		html.dark #set-now:link,
+		html.dark #set-now:visited,
+		body.dark .content-container h2 a:link,
+		body.dark .content-container h2 a:visited,
+		body.dark #set-now:link,
+		body.dark #set-now:visited {
+			color: #b9c7ff;
+		}
 		.content-container h2 a:hover {
 			text-decoration: underline;
 		}

--- a/templates/include/footer.tmpl
+++ b/templates/include/footer.tmpl
@@ -43,4 +43,5 @@
 			</div>
 			{{end}}
 		</footer>
+		<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
 {{end}}

--- a/templates/password-collection.tmpl
+++ b/templates/password-collection.tmpl
@@ -1,7 +1,17 @@
 {{define "password-collection"}}<!DOCTYPE HTML>
-<html {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
+<html class="light" {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
 	<head>
 		<meta charset="utf-8">
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 
 		<title>{{.DisplayTitle}}{{if not .SingleUser}} &mdash; {{.SiteName}}{{end}}</title>
 		
@@ -85,4 +95,6 @@
 	  })();
 	} catch (e) {}
 	</script>
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
+	<script src="/js/theme.js"></script>
 </html>{{end}}

--- a/templates/post.tmpl
+++ b/templates/post.tmpl
@@ -1,7 +1,17 @@
 {{define "post"}}<!DOCTYPE HTML>
-<html {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
+<html class="light" {{if .Language}}lang="{{.Language}}"{{end}} dir="{{.Direction}}">
 	<head prefix="og: http://ogp.me/ns#">
 		<meta charset="utf-8">
+		<script type="text/javascript">
+			(function () {
+				var theme = localStorage.getItem('padTheme');
+				if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+					theme = 'dark';
+				}
+				document.documentElement.classList.remove('light', 'dark');
+				document.documentElement.classList.add(theme || 'light');
+			})();
+		</script>
 
 		<title>{{if .Title}}{{.Title}}{{else}}{{.GenTitle}}{{end}} {{localhtml "title dash" .Language}} {{.SiteName}}</title>
 		
@@ -99,4 +109,6 @@
 		}
 	}
 	</script>
+	<a id="global-theme-toggle" class="global-theme-toggle global-theme-toggle--floating" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
+	<script src="/js/theme.js"></script>
 </html>{{end}}

--- a/templates/user/include/footer.tmpl
+++ b/templates/user/include/footer.tmpl
@@ -20,7 +20,7 @@
 			{{end}}
 		</nav>
 	</footer>
-
+	<script type="text/javascript" src="/js/theme.js"></script>
 	<script type="text/javascript" src="/js/menu.js"></script>
 	<script type="text/javascript">
 	try { // Google Fonts

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -16,9 +16,9 @@
 					</ul>
 				</nav>
 				<nav class="tabs">
-					<a href="/me/c/{{.UserPage.Username}}" {{if and (hasPrefix .Path "/me/c/") (hasSuffix .Path .UserPage.Username)}}class="selected"{{end}}>Customize</a>
-					<a href="/me/c/{{.UserPage.Username}}/stats" {{if hasSuffix .Path "/stats"}}class="selected"{{end}}>Stats</a>
-					<a href="/me/c/{{.UserPage.Username}}/subscribers" {{if hasSuffix .Path "/subscribers"}}class="selected"{{end}}>Subscribers</a>
+					<a href="/me/c/{{.Username}}" {{if and (hasPrefix .Path "/me/c/") (hasSuffix .Path .Username)}}class="selected"{{end}}>Customize</a>
+					<a href="/me/c/{{.Username}}/stats" {{if hasSuffix .Path "/stats"}}class="selected"{{end}}>Stats</a>
+					<a href="/me/c/{{.Username}}/subscribers" {{if hasSuffix .Path "/subscribers"}}class="selected"{{end}}>Subscribers</a>
 					<a href="/me/posts/"{{if eq .Path "/me/posts/"}} class="selected"{{end}}>Drafts</a>
 				</nav>
 			</nav>

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -16,9 +16,9 @@
 					</ul>
 				</nav>
 				<nav class="tabs">
-					<a href="/me/c/{{.Username}}" {{if and (hasPrefix .Path "/me/c/") (hasSuffix .Path .Username)}}class="selected"{{end}}>Customize</a>
-					<a href="/me/c/{{.Username}}/stats" {{if hasSuffix .Path "/stats"}}class="selected"{{end}}>Stats</a>
-					<a href="/me/c/{{.Username}}/subscribers" {{if hasSuffix .Path "/subscribers"}}class="selected"{{end}}>Subscribers</a>
+					<a href="/me/c/{{if .CollAlias}}{{.CollAlias}}{{else}}{{.Username}}{{end}}" {{if and (hasPrefix .Path "/me/c/") (or (and .CollAlias (hasSuffix .Path .CollAlias)) (and .Username (hasSuffix .Path .Username)))}}class="selected"{{end}}>Customize</a>
+					<a href="/me/c/{{if .CollAlias}}{{.CollAlias}}{{else}}{{.Username}}{{end}}/stats" {{if hasSuffix .Path "/stats"}}class="selected"{{end}}>Stats</a>
+					<a href="/me/c/{{if .CollAlias}}{{.CollAlias}}{{else}}{{.Username}}{{end}}/subscribers" {{if hasSuffix .Path "/subscribers"}}class="selected"{{end}}>Subscribers</a>
 					<a href="/me/posts/"{{if eq .Path "/me/posts/"}} class="selected"{{end}}>Drafts</a>
 				</nav>
 			</nav>

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -23,6 +23,7 @@
 				</nav>
 			</nav>
 			<div class="right-side">
+				<a class="global-theme-toggle" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
 				<a class="simple-btn" href="/me/new">New Post</a>
 			</div>
 		{{else}}
@@ -69,6 +70,7 @@
 			</nav>
 			{{if .Username}}
 				<div class="right-side">
+					<a class="global-theme-toggle" href="#theme" title="Toggle theme" data-theme-toggle="true"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a>
 					<a class="simple-btn" href="/{{if .CollAlias}}#{{.CollAlias}}{{end}}">New Post</a>
 				</div>
 			{{end}}
@@ -77,12 +79,22 @@
 	</header>
 {{end}}
 {{define "header"}}<!DOCTYPE HTML>
-<html>
+<html class="light">
 <head>
 	<meta charset="utf-8">
 
 	<title>{{.PageTitle}} {{if .Separator}}{{.Separator}}{{else}}&mdash;{{end}} {{.SiteName}}</title>
 
+	<script type="text/javascript">
+		(function () {
+			var theme = localStorage.getItem('padTheme');
+			if (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+				theme = 'dark';
+			}
+			document.documentElement.classList.remove('light', 'dark');
+			document.documentElement.classList.add(theme || 'light');
+		})();
+	</script>
 	<link rel="stylesheet" type="text/css" href="/css/write.css" />
 	{{if .CustomCSS}}<link rel="stylesheet" type="text/css" href="/local/custom.css" />{{end}}
 	<link rel="shortcut icon" href="/favicon.ico" />


### PR DESCRIPTION
This adds a global light / dark theme toggle across the main public and user-facing pages.

It reuses the existing `padTheme` local storage key and editor theme behavior instead of introducing a separate theme system. The change adds a shared `theme.js` helper, applies the stored theme early on page load, and exposes the same toggle outside the editor UI.

Included:
- global theme toggle on public pages
- global theme toggle on user/admin pages
- theme persistence across page loads
- reuse of the existing editor light/dark theme state

Notes:
- this keeps the implementation within the current template + LESS structure
- it does not add new dependencies

Tested manually on:
- public collection pages
- single post pages
- user dashboard pages
- editor pages
- metadata edit page

- [x] I have signed the [CLA](https://todo.musing.studio/L1)


