### PR TITLE
Refactor: Email Subscription shortcode and form

### DIFF
--- a/email.go
+++ b/email.go
@@ -322,7 +322,7 @@ func emailPost(app *App, p *PublicPost, collID int64) error {
 
 	// Do some shortcode replacement.
 	// Since the user is receiving this email, we can assume they're subscribed via email.
-	p.Content = strings.Replace(p.Content, "<!--emailsub-->", `<p id="emailsub">You're subscribed to email updates.</p>`, -1)
+	p.Content = strings.Replace(p.Content, shortCodeEmailSub, `<p id="emailsub">You're subscribed to email updates.</p>`, -1)
 
 	if p.HTMLContent == template.HTML("") {
 		p.formatContent(app.cfg, false, false)

--- a/postrender.go
+++ b/postrender.go
@@ -31,6 +31,7 @@ import (
 	"github.com/writeas/web-core/stringmanip"
 	"github.com/writefreely/writefreely/config"
 	"github.com/writefreely/writefreely/parse"
+	"github.com/writefreely/writefreely/spam"
 )
 
 var (
@@ -360,4 +361,13 @@ func handleRenderMarkdown(app *App, w http.ResponseWriter, r *http.Request) erro
 	}
 
 	return impart.WriteSuccess(w, out, http.StatusOK)
+}
+
+func alterShortCodeEmailSubForm(postContent, alias, slug string, isDisabled bool) string {
+	subURL := `/api/collections/` + alias + `/email/subscribe`
+	if isDisabled {
+		subURL = ""
+	}
+	formHTML := `<form method="post" id="emailsub" action="` + subURL + `"><input type="hidden" name="slug" value="` + slug + `" /><input type="hidden" name="web" value="1" /><div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="email" name="` + spam.HoneypotFieldName() + `" tabindex="-1" value="" /><input type="password" name="fake_password" tabindex="-1" placeholder="password" autocomplete="new-password" /></div><input type="email" name="email" placeholder="me@example.com" /><input type="submit" id="subscribe-btn" value="Subscribe" /></form>`
+	return strings.Replace(postContent, shortCodeEmailSub, formHTML, -1)
 }

--- a/postrender.go
+++ b/postrender.go
@@ -273,6 +273,8 @@ func getSanitizationPolicy() *bluemonday.Policy {
 	policy.AllowAttrs("style", "class", "id").Globally()
 	policy.AllowAttrs("alt").OnElements("img")
 	policy.AllowElements("header", "footer")
+	policy.AllowAttrs("method", "action").OnElements("form")
+	policy.AllowAttrs("type", "name", "value", "placeholder").OnElements("input")
 	policy.AllowURLSchemes("http", "https", "mailto", "xmpp", "gopher", "gophers", "gemini", "spartan")
 	return policy
 }

--- a/posts.go
+++ b/posts.go
@@ -38,7 +38,6 @@ import (
 	"github.com/writeas/web-core/tags"
 	"github.com/writefreely/writefreely/page"
 	"github.com/writefreely/writefreely/parse"
-	"github.com/writefreely/writefreely/spam"
 )
 
 const (
@@ -56,9 +55,10 @@ type PostType string
 const (
 	postArch PostType = "archive"
 
-	shortCodeMore  = "<!--more-->"
-	shortCodePaid  = "<!--paid-->"
-	shortCodeNoSig = "<!--nosig-->"
+	shortCodeMore     = "<!--more-->"
+	shortCodePaid     = "<!--paid-->"
+	shortCodeNoSig    = "<!--nosig-->"
+	shortCodeEmailSub = "<!--emailsub-->"
 )
 
 type (
@@ -1634,9 +1634,9 @@ Are you sure it was ever here?` + shortCodeNoSig,
 		if app.cfg.Email.Enabled() && c.EmailSubsEnabled() {
 			// TODO: indicate plan is inactive or subs disabled when OWNER is viewing their own post.
 			if u != nil && u.IsEmailSubscriber(app, c.ID) {
-				p.Content = strings.Replace(p.Content, "<!--emailsub-->", `<p id="emailsub">You're subscribed to email updates. <a href="/api/collections/`+c.Alias+`/email/unsubscribe?slug=`+p.Slug.String+`">Unsubscribe</a>.</p>`, -1)
+				p.Content = strings.Replace(p.Content, shortCodeEmailSub, `<p id="emailsub">You're subscribed to email updates. <a href="/api/collections/`+c.Alias+`/email/unsubscribe?slug=`+p.Slug.String+`">Unsubscribe</a>.</p>`, -1)
 			} else {
-				p.Content = strings.Replace(p.Content, "<!--emailsub-->", `<form method="post" id="emailsub" action="/api/collections/`+c.Alias+`/email/subscribe"><input type="hidden" name="slug" value="`+p.Slug.String+`" /><input type="hidden" name="web" value="1" /><div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="email" name="`+spam.HoneypotFieldName()+`" tabindex="-1" value="" /><input type="password" name="fake_password" tabindex="-1" placeholder="password" autocomplete="new-password" /></div><input type="email" name="email" placeholder="me@example.com" /><input type="submit" id="subscribe-btn" value="Subscribe" /></form>`, -1)
+				p.Content = alterShortCodeEmailSubForm(p.Content, c.Alias, p.Slug.String, false)
 			}
 		}
 		p.Content = strings.Replace(p.Content, "&lt;!--emailsub-->", "<!--emailsub-->", 1)


### PR DESCRIPTION
Some minor refactoring. This puts the `<!--emailsub-->` shortcode into a constant, and puts all the form logic in one function, so it can be used in various places.

This also allow-lists the `form` elements needed to actually render the subscription form via this shortcode. Previously, these elements were stripped out of rendered posts (#1520).

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
