### PR TITLE
Document MariaDB support in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The quickest way to deploy WriteFreely is with [Write.as](https://write.as/write
 
 ## Quick start
 
-WriteFreely deploys as a static binary on any platform and architecture that Go supports. Just use our built-in SQLite support, or add a MySQL database, and you'll be up and running!
+WriteFreely deploys as a static binary on any platform and architecture that Go supports. Just use our built-in SQLite support, or add a MySQL or MariaDB database, and you'll be up and running!
 
 For common platforms, start with our [pre-built binaries](https://github.com/writefreely/writefreely/releases/) and head over to our [installation guide](https://writefreely.org/start) to get started.
 


### PR DESCRIPTION
Mention MariaDB alongside MySQL in the quick start as the project's Docker Compose ships a MariaDB image; the app uses the MySQL driver (type = mysql).
---
- [X] I have signed the [CLA](https://todo.musing.studio/L1)
