### PR TITLE
make OAuth Adapter RFC-compliant

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -102,21 +102,22 @@ type (
 	}
 
 	GenericOauthCfg struct {
-		ClientID         string `ini:"client_id"`
-		ClientSecret     string `ini:"client_secret"`
-		Host             string `ini:"host"`
-		DisplayName      string `ini:"display_name"`
-		CallbackProxy    string `ini:"callback_proxy"`
-		CallbackProxyAPI string `ini:"callback_proxy_api"`
-		TokenEndpoint    string `ini:"token_endpoint"`
-		InspectEndpoint  string `ini:"inspect_endpoint"`
-		AuthEndpoint     string `ini:"auth_endpoint"`
-		Scope            string `ini:"scope"`
-		AllowDisconnect  bool   `ini:"allow_disconnect"`
-		MapUserID        string `ini:"map_user_id"`
-		MapUsername      string `ini:"map_username"`
-		MapDisplayName   string `ini:"map_display_name"`
-		MapEmail         string `ini:"map_email"`
+		ClientID           string `ini:"client_id"`
+		ClientSecret       string `ini:"client_secret"`
+		Host               string `ini:"host"`
+		DisplayName        string `ini:"display_name"`
+		CallbackProxy      string `ini:"callback_proxy"`
+		CallbackProxyAPI   string `ini:"callback_proxy_api"`
+		TokenEndpoint      string `ini:"token_endpoint"`
+		InspectEndpoint    string `ini:"inspect_endpoint"`
+		AuthEndpoint       string `ini:"auth_endpoint"`
+		AuthUseRequestBody bool   `ini:"auth_use_basic_auth"`
+		Scope              string `ini:"scope"`
+		AllowDisconnect    bool   `ini:"allow_disconnect"`
+		MapUserID          string `ini:"map_user_id"`
+		MapUsername        string `ini:"map_username"`
+		MapDisplayName     string `ini:"map_display_name"`
+		MapEmail           string `ini:"map_email"`
 	}
 
 	// AppCfg holds values that affect how the application functions

--- a/oauth_generic.go
+++ b/oauth_generic.go
@@ -22,18 +22,19 @@ import (
 )
 
 type genericOauthClient struct {
-	ClientID         string
-	ClientSecret     string
-	AuthLocation     string
-	ExchangeLocation string
-	InspectLocation  string
-	CallbackLocation string
-	Scope            string
-	MapUserID        string
-	MapUsername      string
-	MapDisplayName   string
-	MapEmail         string
-	HttpClient       HttpClient
+	ClientID           string
+	ClientSecret       string
+	AuthUseRequestBody bool
+	AuthLocation       string
+	ExchangeLocation   string
+	InspectLocation    string
+	CallbackLocation   string
+	Scope              string
+	MapUserID          string
+	MapUsername        string
+	MapDisplayName     string
+	MapEmail           string
+	HttpClient         HttpClient
 }
 
 var _ oauthClient = genericOauthClient{}
@@ -71,8 +72,10 @@ func (c genericOauthClient) buildLoginURL(state string) (string, error) {
 
 func (c genericOauthClient) exchangeOauthCode(ctx context.Context, code string) (*TokenResponse, error) {
 	form := url.Values{}
-	form.Add("client_id", c.ClientID)
-	form.Add("client_secret", c.ClientSecret)
+	if c.AuthUseRequestBody {
+		form.Add("client_id", c.ClientID)
+		form.Add("client_secret", c.ClientSecret)
+	}
 	form.Add("grant_type", "authorization_code")
 	form.Add("redirect_uri", c.CallbackLocation)
 	form.Add("scope", c.Scope)
@@ -85,7 +88,9 @@ func (c genericOauthClient) exchangeOauthCode(ctx context.Context, code string) 
 	req.Header.Set("User-Agent", ServerUserAgent(""))
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.SetBasicAuth(c.ClientID, c.ClientSecret)
+	if !c.AuthUseRequestBody {
+		req.SetBasicAuth(c.ClientID, c.ClientSecret)
+	}
 
 	resp, err := c.HttpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
RFC 6749 §2.3.1 states: "The client MUST NOT use more than one authentication method in each request." Currently, writefreely always sends both thus requiring a compliant OAuth provider to reject the request. Add an option to send the credentials in the body, if required and disable Basic Auth in this case.

Link: https://datatracker.ietf.org/doc/html/rfc6749#section-2.3
Fixes: #1241

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
