### PR TITLE
Prevent signups via /auth/signup with closed registrations

### DIFF
--- a/unregisteredusers.go
+++ b/unregisteredusers.go
@@ -44,6 +44,9 @@ func handleWebSignup(app *App, w http.ResponseWriter, r *http.Request) error {
 			return ErrBadFormData
 		}
 	}
+	if !app.cfg.App.OpenRegistration && ur.InviteCode == "" {
+		return impart.HTTPError{http.StatusForbidden, "Registration is closed"}
+	}
 	ur.Web = true
 	ur.Normalize = true
 


### PR DESCRIPTION
Previously, there was no check in place on the web-based /auth/signup endpoint to ensure users can't still be created while registrations are closed.

Fixes #1649

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
