### PR TITLE
Fix missing user nav on blog Customize page

### DIFF
--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -30,9 +30,9 @@
 				<h1><a href="/" title="Return to editor">{{.SiteName}}</a></h1>
 			</div>
 			<nav id="user-nav">
-				{{if .Username}}
+				{{if .UserPage.Username}}
 				<nav class="dropdown-nav">
-					<ul><li class="has-submenu"><a>{{.Username}}</a> <img class="ic-18dp" src="/img/ic_down_arrow_dark@2x.png" /><ul>
+					<ul><li class="has-submenu"><a>{{.UserPage.Username}}</a> <img class="ic-18dp" src="/img/ic_down_arrow_dark@2x.png" /><ul>
 							{{if .IsAdmin}}<li><a href="/admin">Admin dashboard</a></li>{{end}}
 							<li><a href="/me/settings">Account settings</a></li>
 							<li><a href="/me/import">Import posts</a></li>
@@ -51,14 +51,14 @@
 						{{ end }}
 						<a href="/about">About</a>
 						{{ if not .SingleUser }}
-							{{ if .Username }}
+							{{ if .UserPage.Username }}
 						{{if gt .MaxBlogs 1}}<a href="/me/c/"{{if eq .Path "/me/c/"}} class="selected"{{end}}>Blogs</a>{{end}}
-						{{if and .Chorus (eq .MaxBlogs 1)}}<a href="/{{.Username}}/"{{if eq .Path (printf "/%s/" .Username)}} class="selected"{{end}}>My Posts</a>{{end}}
+						{{if and .Chorus (eq .MaxBlogs 1)}}<a href="/{{.UserPage.Username}}/"{{if eq .Path (printf "/%s/" .UserPage.Username)}} class="selected"{{end}}>My Posts</a>{{end}}
 						{{if not .DisableDrafts}}<a href="/me/posts/"{{if eq .Path "/me/posts/"}} class="selected"{{end}}>Drafts</a>{{end}}
 							{{ end }}
 						{{if and (and .LocalTimeline .CanViewReader) (not .Chorus)}}<a href="/read">Reader</a>{{end}}
-						{{if and (and (and .Chorus .OpenRegistration) (not .Username)) (or (not .Private) (ne .Landing ""))}}<a href="/signup"{{if eq .Path "/signup"}} class="selected"{{end}}>Sign up</a>{{end}}
-						{{if .Username}}<a href="/me/logout">Log out</a>{{else}}<a href="/login">Log in</a>{{end}}
+						{{if and (and (and .Chorus .OpenRegistration) (not .UserPage.Username)) (or (not .Private) (ne .Landing ""))}}<a href="/signup"{{if eq .Path "/signup"}} class="selected"{{end}}>Sign up</a>{{end}}
+						{{if .UserPage.Username}}<a href="/me/logout">Log out</a>{{else}}<a href="/login">Log in</a>{{end}}
 						{{ end }}
 					{{else}}
 						<a href="/me/c/"{{if eq .Path "/me/c/"}} class="selected"{{end}}>Blogs</a>
@@ -67,7 +67,7 @@
 					{{end}}
 				</nav>
 			</nav>
-			{{if .Username}}
+			{{if .UserPage.Username}}
 				<div class="right-side">
 					<a class="simple-btn" href="/{{if .CollAlias}}#{{.CollAlias}}{{end}}">New Post</a>
 				</div>


### PR DESCRIPTION
Previously, user navigation and the _New Post_ button wouldn't show up on the blog Customize page.

Continuing the fixes in #1505, this now ensures the `.Username` is always populated in the navigation bar, so these elements show up.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
