### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ WriteFreely deploys as a static binary on any platform and architecture that Go 
 
 For common platforms, start with our [pre-built binaries](https://github.com/writefreely/writefreely/releases/) and head over to our [installation guide](https://writefreely.org/start) to get started.
 
+Prefer not to run a server? Deploy a fully managed instance with one click:
+
+[![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/writefreely)
+
 ### Packages
 
 You can also find WriteFreely in these package repositories, thanks to our wonderful community!


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added WriteFreely to our marketplace, so this PR adds a small "Deploy with Zenith" badge in the Quick start section (links to https://zenith.hosting/host/writefreely).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting