### PR TITLE
Fix nodeinfo Active User stats for SQLite-backed instances

### DIFF
--- a/nodeinfo.go
+++ b/nodeinfo.go
@@ -94,7 +94,7 @@ FROM posts
 INNER JOIN collections c
 ON collection_id = c.id
 WHERE collection_id IS NOT NULL
-	AND updated > DATE_SUB(NOW(), INTERVAL 6 MONTH)) co`).Scan(&activeHalfYear)
+	AND updated > ` + r.db.dateSub(6, "MONTH") + `) co`).Scan(&activeHalfYear)
 		if err != nil {
 			log.Error("Failed getting 6-month active user stats: %s", err)
 		}
@@ -105,7 +105,7 @@ FROM posts
 INNER JOIN collections c
 ON collection_id = c.id
 WHERE collection_id IS NOT NULL
-	AND updated > DATE_SUB(NOW(), INTERVAL 1 MONTH)) co`).Scan(&activeMonth)
+	AND updated > ` + r.db.dateSub(1, "MONTH") + `) co`).Scan(&activeMonth)
 		if err != nil {
 			log.Error("Failed getting 1-month active user stats: %s", err)
 		}


### PR DESCRIPTION
Previously, the `activeHalfYear` and `activeMonth` attributes would always be `0` on SQLite-backed instances, due to a bad database query.

Fixes another issue brought up in #659.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
