### PR TITLE
Add mass user management via command-line

### DIFF
--- a/app.go
+++ b/app.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+	"text/tabwriter"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -841,6 +842,112 @@ func DoDeleteAccount(apper Apper, username string) error {
 		os.Exit(1)
 	}
 	log.Info("Success.")
+	return nil
+}
+
+// UserAction is a bulk moderation action applied to a filtered set of users.
+type UserAction int
+
+const (
+	// ActionList only prints matching users, changing nothing.
+	ActionList UserAction = iota
+	// ActionSilence silences all matching users.
+	ActionSilence
+	// ActionDelete permanently deletes all matching users and their content.
+	ActionDelete
+)
+
+// ModerateUsers lists users matching the given filter and, when action is
+// ActionSilence or ActionDelete, applies that action to the whole set after a
+// single confirmation prompt. It's the backend for the `users` command,
+// intended for cleaning up waves of spam signups.
+func ModerateUsers(apper Apper, filter UserFilter, action UserAction) error {
+	// Connect to the database
+	apper.LoadConfig()
+	connectToDatabase(apper.App())
+	defer shutdown(apper.App())
+
+	app := apper.App()
+
+	users, err := app.db.GetUsersFiltered(filter)
+	if err != nil {
+		log.Error("%s", err)
+		os.Exit(1)
+	}
+
+	// Print the matching users
+	fmt.Printf("Matched %d users:\n", len(users))
+	if len(users) > 0 {
+		w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tUSERNAME\tCREATED\tPOSTS\tSTATUS")
+		for _, u := range users {
+			status := ""
+			if u.IsSilenced() {
+				status = "silenced"
+			}
+			fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\n", u.ID, u.Username, u.Created.Format("2006-01-02 15:04 MST"), u.PostCount, status)
+		}
+		w.Flush()
+	}
+	fmt.Printf("(%d total)\n", len(users))
+
+	// List-only: nothing more to do
+	if action == ActionList {
+		return nil
+	}
+
+	// Nothing to act on
+	if len(users) == 0 {
+		log.Info("No users to act on.")
+		return nil
+	}
+
+	// Confirm the action, echoing the count and verb
+	verb := "SILENCE"
+	if action == ActionDelete {
+		verb = "DELETE"
+	}
+	label := fmt.Sprintf("Really %s %d users", verb, len(users))
+	if action == ActionDelete {
+		label += " and all their content? This cannot be undone"
+	}
+	prompt := promptui.Prompt{
+		Templates: &promptui.PromptTemplates{
+			Success: "{{ . | bold | faint }}: ",
+		},
+		Label:     label,
+		IsConfirm: true,
+	}
+	if _, err = prompt.Run(); err != nil {
+		log.Info("Aborted...")
+		return nil
+	}
+
+	// Apply the action, isolating per-user errors so one failure doesn't
+	// halt the whole batch.
+	log.Info("Working...")
+	var done, failed int
+	for _, u := range users {
+		switch action {
+		case ActionSilence:
+			err = app.db.SetUserStatus(u.ID, UserSilenced)
+		case ActionDelete:
+			err = app.db.DeleteAccount(u.ID)
+		}
+		if err != nil {
+			log.Error("Failed on user %s (%d): %v", u.Username, u.ID, err)
+			failed++
+			continue
+		}
+		done++
+	}
+
+	// Silenced users' posts may be cached in the timeline; refresh it once.
+	if action == ActionSilence && done > 0 && app.timeline != nil {
+		updateTimelineCache(app.timeline, true)
+	}
+
+	log.Info("Done. %d/%d succeeded, %d errors.", done, len(users), failed)
 	return nil
 }
 

--- a/app.go
+++ b/app.go
@@ -869,6 +869,10 @@ func ModerateUsers(apper Apper, filter UserFilter, action UserAction) error {
 
 	app := apper.App()
 
+	// Admins are only ever included when listing; silence/delete must never
+	// touch them, regardless of the filter passed in.
+	filter.IncludeAdmins = action == ActionList
+
 	users, err := app.db.GetUsersFiltered(filter)
 	if err != nil {
 		log.Error("%s", err)
@@ -882,7 +886,9 @@ func ModerateUsers(apper Apper, filter UserFilter, action UserAction) error {
 		fmt.Fprintln(w, "ID\tUSERNAME\tCREATED\tPOSTS\tSTATUS")
 		for _, u := range users {
 			status := ""
-			if u.IsSilenced() {
+			if u.IsAdmin() {
+				status = "admin"
+			} else if u.IsSilenced() {
 				status = "silenced"
 			}
 			fmt.Fprintf(w, "%d\t%s\t%s\t%d\t%s\n", u.ID, u.Username, u.Created.Format("2006-01-02 15:04 MST"), u.PostCount, status)

--- a/cmd/writefreely/main.go
+++ b/cmd/writefreely/main.go
@@ -109,6 +109,7 @@ func main() {
 
 	app.Commands = []*cli.Command{
 		&cmdUser,
+		&cmdUsers,
 		&cmdDB,
 		&cmdConfig,
 		&cmdKeys,

--- a/cmd/writefreely/user.go
+++ b/cmd/writefreely/user.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/urfave/cli/v2"
 	"github.com/writefreely/writefreely"
@@ -56,6 +57,52 @@ var (
 		Aliases: []string{"resetpass", "reset"},
 		Action:  resetPassAction,
 	}
+
+	cmdUsers cli.Command = cli.Command{
+		Name:  "users",
+		Usage: "mass user moderation tools",
+		Subcommands: []*cli.Command{
+			&cmdListUsers,
+		},
+	}
+
+	cmdListUsers cli.Command = cli.Command{
+		Name:    "list",
+		Usage:   "List users matching filters, or act on them with --silence/--delete",
+		Aliases: []string{"ls"},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:  "since",
+				Usage: "Only users created on/after this date (YYYY-MM-DD)",
+			},
+			&cli.StringFlag{
+				Name:  "until",
+				Usage: "Only users created before this date (YYYY-MM-DD)",
+			},
+			&cli.BoolFlag{
+				Name:  "no-invite",
+				Usage: "Only users who signed up without an invite code",
+			},
+			&cli.BoolFlag{
+				Name:  "no-oauth",
+				Usage: "Only users who did not register via an OAuth provider",
+			},
+			&cli.IntFlag{
+				Name:  "max-posts",
+				Value: -1,
+				Usage: "Only users with at most N posts (-1 = no limit)",
+			},
+			&cli.BoolFlag{
+				Name:  "silence",
+				Usage: "Silence all matched users",
+			},
+			&cli.BoolFlag{
+				Name:  "delete",
+				Usage: "Delete all matched users and their content",
+			},
+		},
+		Action: listUsersAction,
+	}
 )
 
 func addUserAction(c *cli.Context) error {
@@ -93,4 +140,41 @@ func resetPassAction(c *cli.Context) error {
 	}
 	app := writefreely.NewApp(c.String("c"))
 	return writefreely.ResetPassword(app, username)
+}
+
+func listUsersAction(c *cli.Context) error {
+	if c.Bool("silence") && c.Bool("delete") {
+		return fmt.Errorf("--silence and --delete cannot be used together")
+	}
+
+	const dateFmt = "2006-01-02"
+	filter := writefreely.UserFilter{
+		NoInvite: c.Bool("no-invite"),
+		NoOAuth:  c.Bool("no-oauth"),
+		MaxPosts: c.Int("max-posts"),
+	}
+	if s := c.String("since"); s != "" {
+		t, err := time.Parse(dateFmt, s)
+		if err != nil {
+			return fmt.Errorf("invalid --since date %q, expected YYYY-MM-DD", s)
+		}
+		filter.Since = &t
+	}
+	if s := c.String("until"); s != "" {
+		t, err := time.Parse(dateFmt, s)
+		if err != nil {
+			return fmt.Errorf("invalid --until date %q, expected YYYY-MM-DD", s)
+		}
+		filter.Until = &t
+	}
+
+	action := writefreely.ActionList
+	if c.Bool("silence") {
+		action = writefreely.ActionSilence
+	} else if c.Bool("delete") {
+		action = writefreely.ActionDelete
+	}
+
+	app := writefreely.NewApp(c.String("c"))
+	return writefreely.ModerateUsers(app, filter, action)
 }

--- a/cmd/writefreely/user.go
+++ b/cmd/writefreely/user.go
@@ -63,47 +63,63 @@ var (
 		Usage: "mass user moderation tools",
 		Subcommands: []*cli.Command{
 			&cmdListUsers,
+			&cmdSilenceUsers,
+			&cmdDeleteUsers,
 		},
 	}
 
 	cmdListUsers cli.Command = cli.Command{
 		Name:    "list",
-		Usage:   "List users matching filters, or act on them with --silence/--delete",
+		Usage:   "List users matching filters",
 		Aliases: []string{"ls"},
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "since",
-				Usage: "Only users created on/after this date (YYYY-MM-DD)",
-			},
-			&cli.StringFlag{
-				Name:  "until",
-				Usage: "Only users created before this date (YYYY-MM-DD)",
-			},
-			&cli.BoolFlag{
-				Name:  "no-invite",
-				Usage: "Only users who signed up without an invite code",
-			},
-			&cli.BoolFlag{
-				Name:  "no-oauth",
-				Usage: "Only users who did not register via an OAuth provider",
-			},
-			&cli.IntFlag{
-				Name:  "max-posts",
-				Value: -1,
-				Usage: "Only users with at most N posts (-1 = no limit)",
-			},
-			&cli.BoolFlag{
-				Name:  "silence",
-				Usage: "Silence all matched users",
-			},
-			&cli.BoolFlag{
-				Name:  "delete",
-				Usage: "Delete all matched users and their content",
-			},
-		},
-		Action: listUsersAction,
+		Flags:   userFilterFlags(),
+		Action:  listUsersAction,
+	}
+
+	cmdSilenceUsers cli.Command = cli.Command{
+		Name:   "silence",
+		Usage:  "Silence all users matching filters, with confirmation",
+		Flags:  userFilterFlags(),
+		Action: silenceUsersAction,
+	}
+
+	cmdDeleteUsers cli.Command = cli.Command{
+		Name:   "delete",
+		Usage:  "Delete all users matching filters and their content, with confirmation",
+		Flags:  userFilterFlags(),
+		Action: deleteUsersAction,
 	}
 )
+
+// userFilterFlags returns the shared filter flags used by the `users`
+// subcommands (list/silence/delete). A fresh slice is returned per call so the
+// same flag definition is the single source of truth without sharing flag
+// state across sibling commands.
+func userFilterFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "since",
+			Usage: "Only users created on/after this date (YYYY-MM-DD)",
+		},
+		&cli.StringFlag{
+			Name:  "until",
+			Usage: "Only users created before this date (YYYY-MM-DD)",
+		},
+		&cli.BoolFlag{
+			Name:  "no-invite",
+			Usage: "Only users who signed up without an invite code",
+		},
+		&cli.BoolFlag{
+			Name:  "no-oauth",
+			Usage: "Only users who did not register via an OAuth provider",
+		},
+		&cli.IntFlag{
+			Name:  "max-posts",
+			Value: -1,
+			Usage: "Only users with at most N posts (-1 = no limit)",
+		},
+	}
+}
 
 func addUserAction(c *cli.Context) error {
 	credentials := ""
@@ -142,11 +158,9 @@ func resetPassAction(c *cli.Context) error {
 	return writefreely.ResetPassword(app, username)
 }
 
-func listUsersAction(c *cli.Context) error {
-	if c.Bool("silence") && c.Bool("delete") {
-		return fmt.Errorf("--silence and --delete cannot be used together")
-	}
-
+// userFilterFromContext builds a UserFilter from the shared filter flags,
+// returning a clear error on malformed dates.
+func userFilterFromContext(c *cli.Context) (writefreely.UserFilter, error) {
 	const dateFmt = "2006-01-02"
 	filter := writefreely.UserFilter{
 		NoInvite: c.Bool("no-invite"),
@@ -156,25 +170,37 @@ func listUsersAction(c *cli.Context) error {
 	if s := c.String("since"); s != "" {
 		t, err := time.Parse(dateFmt, s)
 		if err != nil {
-			return fmt.Errorf("invalid --since date %q, expected YYYY-MM-DD", s)
+			return filter, fmt.Errorf("invalid --since date %q, expected YYYY-MM-DD", s)
 		}
 		filter.Since = &t
 	}
 	if s := c.String("until"); s != "" {
 		t, err := time.Parse(dateFmt, s)
 		if err != nil {
-			return fmt.Errorf("invalid --until date %q, expected YYYY-MM-DD", s)
+			return filter, fmt.Errorf("invalid --until date %q, expected YYYY-MM-DD", s)
 		}
 		filter.Until = &t
 	}
+	return filter, nil
+}
 
-	action := writefreely.ActionList
-	if c.Bool("silence") {
-		action = writefreely.ActionSilence
-	} else if c.Bool("delete") {
-		action = writefreely.ActionDelete
+func moderateUsersAction(c *cli.Context, action writefreely.UserAction) error {
+	filter, err := userFilterFromContext(c)
+	if err != nil {
+		return err
 	}
-
 	app := writefreely.NewApp(c.String("c"))
 	return writefreely.ModerateUsers(app, filter, action)
+}
+
+func listUsersAction(c *cli.Context) error {
+	return moderateUsersAction(c, writefreely.ActionList)
+}
+
+func silenceUsersAction(c *cli.Context) error {
+	return moderateUsersAction(c, writefreely.ActionSilence)
+}
+
+func deleteUsersAction(c *cli.Context) error {
+	return moderateUsersAction(c, writefreely.ActionDelete)
 }

--- a/cmd/writefreely/user.go
+++ b/cmd/writefreely/user.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/urfave/cli/v2"
 	"github.com/writefreely/writefreely"
@@ -26,7 +25,6 @@ var (
 			&cmdAddUser,
 			&cmdDelUser,
 			&cmdResetPass,
-			// TODO: possibly add a user list command
 		},
 	}
 
@@ -57,69 +55,7 @@ var (
 		Aliases: []string{"resetpass", "reset"},
 		Action:  resetPassAction,
 	}
-
-	cmdUsers cli.Command = cli.Command{
-		Name:  "users",
-		Usage: "mass user moderation tools",
-		Subcommands: []*cli.Command{
-			&cmdListUsers,
-			&cmdSilenceUsers,
-			&cmdDeleteUsers,
-		},
-	}
-
-	cmdListUsers cli.Command = cli.Command{
-		Name:    "list",
-		Usage:   "List users matching filters",
-		Aliases: []string{"ls"},
-		Flags:   userFilterFlags(),
-		Action:  listUsersAction,
-	}
-
-	cmdSilenceUsers cli.Command = cli.Command{
-		Name:   "silence",
-		Usage:  "Silence all users matching filters, with confirmation",
-		Flags:  userFilterFlags(),
-		Action: silenceUsersAction,
-	}
-
-	cmdDeleteUsers cli.Command = cli.Command{
-		Name:   "delete",
-		Usage:  "Delete all users matching filters and their content, with confirmation",
-		Flags:  userFilterFlags(),
-		Action: deleteUsersAction,
-	}
 )
-
-// userFilterFlags returns the shared filter flags used by the `users`
-// subcommands (list/silence/delete). A fresh slice is returned per call so the
-// same flag definition is the single source of truth without sharing flag
-// state across sibling commands.
-func userFilterFlags() []cli.Flag {
-	return []cli.Flag{
-		&cli.StringFlag{
-			Name:  "since",
-			Usage: "Only users created on/after this date (YYYY-MM-DD)",
-		},
-		&cli.StringFlag{
-			Name:  "until",
-			Usage: "Only users created before this date (YYYY-MM-DD)",
-		},
-		&cli.BoolFlag{
-			Name:  "no-invite",
-			Usage: "Only users who signed up without an invite code",
-		},
-		&cli.BoolFlag{
-			Name:  "no-oauth",
-			Usage: "Only users who did not register via an OAuth provider",
-		},
-		&cli.IntFlag{
-			Name:  "max-posts",
-			Value: -1,
-			Usage: "Only users with at most N posts (-1 = no limit)",
-		},
-	}
-}
 
 func addUserAction(c *cli.Context) error {
 	credentials := ""
@@ -156,51 +92,4 @@ func resetPassAction(c *cli.Context) error {
 	}
 	app := writefreely.NewApp(c.String("c"))
 	return writefreely.ResetPassword(app, username)
-}
-
-// userFilterFromContext builds a UserFilter from the shared filter flags,
-// returning a clear error on malformed dates.
-func userFilterFromContext(c *cli.Context) (writefreely.UserFilter, error) {
-	const dateFmt = "2006-01-02"
-	filter := writefreely.UserFilter{
-		NoInvite: c.Bool("no-invite"),
-		NoOAuth:  c.Bool("no-oauth"),
-		MaxPosts: c.Int("max-posts"),
-	}
-	if s := c.String("since"); s != "" {
-		t, err := time.Parse(dateFmt, s)
-		if err != nil {
-			return filter, fmt.Errorf("invalid --since date %q, expected YYYY-MM-DD", s)
-		}
-		filter.Since = &t
-	}
-	if s := c.String("until"); s != "" {
-		t, err := time.Parse(dateFmt, s)
-		if err != nil {
-			return filter, fmt.Errorf("invalid --until date %q, expected YYYY-MM-DD", s)
-		}
-		filter.Until = &t
-	}
-	return filter, nil
-}
-
-func moderateUsersAction(c *cli.Context, action writefreely.UserAction) error {
-	filter, err := userFilterFromContext(c)
-	if err != nil {
-		return err
-	}
-	app := writefreely.NewApp(c.String("c"))
-	return writefreely.ModerateUsers(app, filter, action)
-}
-
-func listUsersAction(c *cli.Context) error {
-	return moderateUsersAction(c, writefreely.ActionList)
-}
-
-func silenceUsersAction(c *cli.Context) error {
-	return moderateUsersAction(c, writefreely.ActionSilence)
-}
-
-func deleteUsersAction(c *cli.Context) error {
-	return moderateUsersAction(c, writefreely.ActionDelete)
 }

--- a/cmd/writefreely/users.go
+++ b/cmd/writefreely/users.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2026 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/urfave/cli/v2"
+	"github.com/writefreely/writefreely"
+)
+
+var (
+	cmdUsers cli.Command = cli.Command{
+		Name:  "users",
+		Usage: "mass user moderation tools",
+		Subcommands: []*cli.Command{
+			&cmdListUsers,
+			&cmdSilenceUsers,
+			&cmdDeleteUsers,
+		},
+	}
+
+	cmdListUsers cli.Command = cli.Command{
+		Name:    "list",
+		Usage:   "List users matching filters",
+		Aliases: []string{"ls"},
+		Flags:   userFilterFlags(),
+		Action:  listUsersAction,
+	}
+
+	cmdSilenceUsers cli.Command = cli.Command{
+		Name:   "silence",
+		Usage:  "Silence all users matching filters, with confirmation",
+		Flags:  userFilterFlags(),
+		Action: silenceUsersAction,
+	}
+
+	cmdDeleteUsers cli.Command = cli.Command{
+		Name:   "delete",
+		Usage:  "Delete all users matching filters and their content, with confirmation",
+		Flags:  userFilterFlags(),
+		Action: deleteUsersAction,
+	}
+)
+
+// userFilterFlags returns the shared filter flags used by the `users`
+// subcommands (list/silence/delete). A fresh slice is returned per call so the
+// same flag definition is the single source of truth without sharing flag
+// state across sibling commands.
+func userFilterFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "since",
+			Usage: "Only users created on/after this date (YYYY-MM-DD)",
+		},
+		&cli.StringFlag{
+			Name:  "until",
+			Usage: "Only users created before this date (YYYY-MM-DD)",
+		},
+		&cli.BoolFlag{
+			Name:  "no-invite",
+			Usage: "Only users who signed up without an invite code",
+		},
+		&cli.BoolFlag{
+			Name:  "no-oauth",
+			Usage: "Only users who did not register via an OAuth provider",
+		},
+		&cli.IntFlag{
+			Name:  "max-posts",
+			Value: -1,
+			Usage: "Only users with at most N posts (-1 = no limit)",
+		},
+	}
+}
+
+// userFilterFromContext builds a UserFilter from the shared filter flags,
+// returning a clear error on malformed dates.
+func userFilterFromContext(c *cli.Context) (writefreely.UserFilter, error) {
+	const dateFmt = "2006-01-02"
+	filter := writefreely.UserFilter{
+		NoInvite: c.Bool("no-invite"),
+		NoOAuth:  c.Bool("no-oauth"),
+		MaxPosts: c.Int("max-posts"),
+	}
+	if s := c.String("since"); s != "" {
+		t, err := time.Parse(dateFmt, s)
+		if err != nil {
+			return filter, fmt.Errorf("invalid --since date %q, expected YYYY-MM-DD", s)
+		}
+		filter.Since = &t
+	}
+	if s := c.String("until"); s != "" {
+		t, err := time.Parse(dateFmt, s)
+		if err != nil {
+			return filter, fmt.Errorf("invalid --until date %q, expected YYYY-MM-DD", s)
+		}
+		filter.Until = &t
+	}
+	return filter, nil
+}
+
+func moderateUsersAction(c *cli.Context, action writefreely.UserAction) error {
+	filter, err := userFilterFromContext(c)
+	if err != nil {
+		return err
+	}
+	app := writefreely.NewApp(c.String("c"))
+	return writefreely.ModerateUsers(app, filter, action)
+}
+
+func listUsersAction(c *cli.Context) error {
+	return moderateUsersAction(c, writefreely.ActionList)
+}
+
+func silenceUsersAction(c *cli.Context) error {
+	return moderateUsersAction(c, writefreely.ActionSilence)
+}
+
+func deleteUsersAction(c *cli.Context) error {
+	return moderateUsersAction(c, writefreely.ActionDelete)
+}

--- a/database.go
+++ b/database.go
@@ -135,6 +135,7 @@ type writestore interface {
 	UpdateDynamicContent(id, title, content, contentType string) error
 	GetAllUsers(page uint) (*[]User, error)
 	GetAllUsersCount() int64
+	GetUsersFiltered(f UserFilter) ([]FilteredUser, error)
 	GetUserLastPostTime(id int64) (*time.Time, error)
 	GetCollectionLastPostTime(id int64) (*time.Time, error)
 
@@ -2907,6 +2908,58 @@ func (db *datastore) GetAllUsersCount() int64 {
 	}
 
 	return count
+}
+
+// GetUsersFiltered returns all non-admin users matching the given filters,
+// each paired with their post count. It intentionally omits pagination: it's
+// used by the `users` moderation command, which needs the full matching set in
+// a single pass. Admins are always excluded so bulk actions can never affect
+// them.
+func (db *datastore) GetUsersFiltered(f UserFilter) ([]FilteredUser, error) {
+	where := []string{"u.id != 1"}
+	var params []interface{}
+
+	if f.Since != nil {
+		where = append(where, "u.created >= ?")
+		params = append(params, *f.Since)
+	}
+	if f.Until != nil {
+		where = append(where, "u.created < ?")
+		params = append(params, *f.Until)
+	}
+	if f.NoInvite {
+		where = append(where, "NOT EXISTS (SELECT 1 FROM usersinvited i WHERE i.user_id = u.id)")
+	}
+	if f.NoOAuth {
+		where = append(where, "NOT EXISTS (SELECT 1 FROM oauth_users o WHERE o.user_id = u.id)")
+	}
+	if f.MaxPosts >= 0 {
+		where = append(where, "(SELECT COUNT(*) FROM posts p WHERE p.owner_id = u.id) <= ?")
+		params = append(params, f.MaxPosts)
+	}
+
+	q := "SELECT u.id, u.username, u.created, u.status, " +
+		"(SELECT COUNT(*) FROM posts p WHERE p.owner_id = u.id) AS post_count " +
+		"FROM users u WHERE " + strings.Join(where, " AND ") + " ORDER BY u.created DESC"
+
+	rows, err := db.Query(q, params...)
+	if err != nil {
+		log.Error("Failed selecting filtered users: %v", err)
+		return nil, impart.HTTPError{http.StatusInternalServerError, "Couldn't retrieve users."}
+	}
+	defer rows.Close()
+
+	users := []FilteredUser{}
+	for rows.Next() {
+		fu := FilteredUser{User: &User{}}
+		err = rows.Scan(&fu.User.ID, &fu.User.Username, &fu.User.Created, &fu.User.Status, &fu.PostCount)
+		if err != nil {
+			log.Error("Failed scanning GetUsersFiltered() row: %v", err)
+			return nil, err
+		}
+		users = append(users, fu)
+	}
+	return users, nil
 }
 
 func (db *datastore) GetUserLastPostTime(id int64) (*time.Time, error) {

--- a/database.go
+++ b/database.go
@@ -2940,7 +2940,7 @@ func (db *datastore) GetUsersFiltered(f UserFilter) ([]FilteredUser, error) {
 
 	q := "SELECT u.id, u.username, u.created, u.status, " +
 		"(SELECT COUNT(*) FROM posts p WHERE p.owner_id = u.id) AS post_count " +
-		"FROM users u WHERE " + strings.Join(where, " AND ") + " ORDER BY u.created DESC"
+		"FROM users u WHERE " + strings.Join(where, " AND ") + " ORDER BY u.created ASC"
 
 	rows, err := db.Query(q, params...)
 	if err != nil {

--- a/database.go
+++ b/database.go
@@ -2910,14 +2910,18 @@ func (db *datastore) GetAllUsersCount() int64 {
 	return count
 }
 
-// GetUsersFiltered returns all non-admin users matching the given filters,
-// each paired with their post count. It intentionally omits pagination: it's
-// used by the `users` moderation command, which needs the full matching set in
-// a single pass. Admins are always excluded so bulk actions can never affect
-// them.
+// GetUsersFiltered returns users matching the given filters, each paired with
+// their post count. It intentionally omits pagination: it's used by the `users`
+// moderation command, which needs the full matching set in a single pass.
+// Admins are excluded unless f.IncludeAdmins is set (listing only) so bulk
+// silence/delete actions can never affect them.
 func (db *datastore) GetUsersFiltered(f UserFilter) ([]FilteredUser, error) {
-	where := []string{"u.id != 1"}
+	var where []string
 	var params []interface{}
+
+	if !f.IncludeAdmins {
+		where = append(where, "u.id != 1")
+	}
 
 	if f.Since != nil {
 		where = append(where, "u.created >= ?")
@@ -2940,7 +2944,11 @@ func (db *datastore) GetUsersFiltered(f UserFilter) ([]FilteredUser, error) {
 
 	q := "SELECT u.id, u.username, u.created, u.status, " +
 		"(SELECT COUNT(*) FROM posts p WHERE p.owner_id = u.id) AS post_count " +
-		"FROM users u WHERE " + strings.Join(where, " AND ") + " ORDER BY u.created ASC"
+		"FROM users u"
+	if len(where) > 0 {
+		q += " WHERE " + strings.Join(where, " AND ")
+	}
+	q += " ORDER BY u.created ASC"
 
 	rows, err := db.Query(q, params...)
 	if err != nil {

--- a/users.go
+++ b/users.go
@@ -88,6 +88,23 @@ type (
 	PublicUser struct {
 		Username string `json:"username"`
 	}
+
+	// UserFilter describes the criteria for selecting users in bulk
+	// moderation actions (see ModerateUsers). A zero value matches all
+	// non-admin users.
+	UserFilter struct {
+		Since, Until *time.Time // account creation window
+		NoInvite     bool       // only users who signed up without an invite
+		NoOAuth      bool       // only users who didn't register via OAuth
+		MaxPosts     int        // only users with at most this many posts; -1 = no limit
+	}
+
+	// FilteredUser pairs a matched user with their post count, for display
+	// and the --max-posts filter.
+	FilteredUser struct {
+		*User
+		PostCount int64
+	}
 )
 
 // EmailClear decrypts and returns the user's email, caching it in the user

--- a/users.go
+++ b/users.go
@@ -93,10 +93,11 @@ type (
 	// moderation actions (see ModerateUsers). A zero value matches all
 	// non-admin users.
 	UserFilter struct {
-		Since, Until *time.Time // account creation window
-		NoInvite     bool       // only users who signed up without an invite
-		NoOAuth      bool       // only users who didn't register via OAuth
-		MaxPosts     int        // only users with at most this many posts; -1 = no limit
+		Since, Until  *time.Time // account creation window
+		NoInvite      bool       // only users who signed up without an invite
+		NoOAuth       bool       // only users who didn't register via OAuth
+		MaxPosts      int        // only users with at most this many posts; -1 = no limit
+		IncludeAdmins bool       // include admins in results (listing only; never for silence/delete)
 	}
 
 	// FilteredUser pairs a matched user with their post count, for display


### PR DESCRIPTION
This adds a new `users` command for reviewing and moderating users in bulk, especially for use when an instance has experienced a wave of spam, or a ton of unwanted signups while registrations were closed, due to the vulnerability (#1649) in WriteFreely 0.16 and earlier.

This adds these subcommands, with the flags below used to filter only likely unwanted accounts:

- `writefreely users list` -- preview matching users (read-only; includes admins)
- `writefreely users silence` -- silence matched users, with confirmation
- `writefreely users delete` -- delete matched users and their content, with confirmation

Each subcommand accepts these flags, which can be combined as AND conditions:

* `--since` / `--until` (creation date)
* `--no-invite` -- only show users who didn't sign up via invite code
* `--no-oauth` -- only show users who didn't sign up via OAuth
* `--max-posts N` -- only show users with `N` posts or fewer

The general workflow is first to run `writefreely users list [filters]` to confirm the set of users you want to take action on. (**Note**: while the `list` subcommand will include admins if applicable, the mass `silence` and `delete` actions will never include them.)

Next, you'll run `writefreely users silence` or `writefreely users delete` _with the same filter flags_ to take action. This will confirm the list of users, and then confirm you want to take action before running.

### Example

To remove likely malicious accounts that have accrued in recent days on your multi-user instance, you could run the following:

```bash
# Review the accounts first
writefreely users list --since 2026-07-16 --no-invite --no-oauth

# If all are correct, delete them (prompts for confirmation)
writefreely users delete --since 2026-07-16 --no-invite --no-oauth
```

On a single-user instance that has accrued any malicious accounts, you can simply run this (your admin account will always be excluded):

```bash
writefreely users delete
```

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
