### PR TITLE
Improvements to automatic Update checking

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -91,16 +91,12 @@ type instanceContent struct {
 	Updated time.Time
 }
 
+// AdminPage holds any additional variables needed to render Admin pages. Currently none.
 type AdminPage struct {
-	UpdateAvailable bool
 }
 
 func NewAdminPage(app *App) *AdminPage {
-	ap := &AdminPage{}
-	if app.updates != nil {
-		ap.UpdateAvailable = app.updates.AreAvailableNoCheck()
-	}
-	return ap
+	return &AdminPage{}
 }
 
 func (c instanceContent) UpdatedFriendly() template.HTML {

--- a/app.go
+++ b/app.go
@@ -388,6 +388,9 @@ func pageForReq(app *App, r *http.Request) page.StaticPage {
 			p.Username = u.Username
 			p.IsAdmin = u != nil && u.IsAdmin()
 			p.CanInvite = canUserInvite(app.cfg, p.IsAdmin)
+			if p.IsAdmin && app.updates != nil {
+				p.UpdateAvailable = app.updates.AreAvailableNoCheck()
+			}
 		}
 	}
 	p.CanViewReader = !app.cfg.App.Private || u != nil

--- a/config/setup.go
+++ b/config/setup.go
@@ -390,6 +390,17 @@ func Configure(fname string, configSections string) (*SetupData, error) {
 			}
 			data.Config.App.Private = fedStatsType == "Private"
 		}
+
+		selPrompt = promptui.Select{
+			Templates: selTmpls,
+			Label:     "Automatically check for updates",
+			Items:     []string{"Yes", "No"},
+		}
+		_, updateCheckType, err := selPrompt.Run()
+		if err != nil {
+			return data, err
+		}
+		data.Config.App.UpdateChecks = updateCheckType == "Yes"
 	}
 
 	return data, Save(data.Config, fname)

--- a/page/page.go
+++ b/page/page.go
@@ -25,13 +25,14 @@ type StaticPage struct {
 	CustomCSS bool
 
 	// Request values
-	Path          string
-	Username      string
-	Values        map[string]string
-	Flashes       []string
-	CanViewReader bool
-	IsAdmin       bool
-	CanInvite     bool
+	Path            string
+	Username        string
+	Values          map[string]string
+	Flashes         []string
+	CanViewReader   bool
+	IsAdmin         bool
+	CanInvite       bool
+	UpdateAvailable bool
 }
 
 // SanitizeHost alters the StaticPage to contain a real hostname. This is

--- a/templates/base.tmpl
+++ b/templates/base.tmpl
@@ -26,7 +26,7 @@
 				{{if .Username}}
 				<nav class="dropdown-nav">
 					<ul><li class="has-submenu"><a>{{.Username}}</a> <img class="ic-18dp" src="/img/ic_down_arrow_dark@2x.png" /><ul>
-							{{if .IsAdmin}}<li><a href="/admin">Admin dashboard</a></li>{{end}}
+							{{if .IsAdmin}}<li><a href="/admin">Admin dashboard{{if and .UpdateChecks .UpdateAvailable}}<span class="blip">!</span>{{end}}</a></li>{{end}}
 							<li><a href="/me/settings">Account settings</a></li>
 							<li><a href="/me/import">Import posts</a></li>
 							<li><a href="/me/export">Export</a></li>

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -105,13 +105,13 @@
 		<a href="/admin" {{if eq .Path "/admin"}}class="selected"{{end}}>Dashboard</a>
 		<a href="/admin/settings" {{if eq .Path "/admin/settings"}}class="selected"{{end}}>Settings</a>
 		{{if not .SingleUser}}
-		<a href="/admin/users" {{if eq .Path "/admin/users"}}class="selected"{{end}}>Users</a>
-		<a href="/admin/pages" {{if eq .Path "/admin/pages"}}class="selected"{{end}}>Pages</a>
+			<a href="/admin/users" {{if eq .Path "/admin/users"}}class="selected"{{end}}>Users</a>
+			<a href="/admin/pages" {{if eq .Path "/admin/pages"}}class="selected"{{end}}>Pages</a>
 		{{end}}
 		{{if .UpdateChecks}}<a href="/admin/updates" {{if eq .Path "/admin/updates"}}class="selected"{{end}}>Updates{{if .UpdateAvailable}}<span class="blip">!</span>{{end}}</a>{{end}}
-		{{if not .Forest}}
-		<a href="/admin/monitor" {{if eq .Path "/admin/monitor"}}class="selected"{{end}}>Monitor</a>
-		{{end}}
+		{{if not .Forest -}}
+			<a href="/admin/monitor" {{if eq .Path "/admin/monitor"}}class="selected"{{end}}>Monitor</a>
+		{{- end}}
 	</nav>
 </header>
 {{end}}

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -6,7 +6,7 @@
 				<nav class="dropdown-nav">
 					<ul><li><a href="/" title="View blog" class="title">{{.SiteName}}</a> <img class="ic-18dp" src="/img/ic_down_arrow_dark@2x.png" />
 						<ul>
-							{{if .IsAdmin}}<li><a href="/admin">Admin dashboard</a></li>{{end}}
+							{{if .IsAdmin}}<li><a href="/admin">Admin dashboard{{if and .UpdateChecks .UpdateAvailable}}<span class="blip">!</span>{{end}}</a></li>{{end}}
 							<li><a href="/me/settings">Account settings</a></li>
 							<li><a href="/me/import">Import posts</a></li>
 							<li><a href="/me/export">Export</a></li>
@@ -33,7 +33,7 @@
 				{{if .UserPage.Username}}
 				<nav class="dropdown-nav">
 					<ul><li class="has-submenu"><a>{{.UserPage.Username}}</a> <img class="ic-18dp" src="/img/ic_down_arrow_dark@2x.png" /><ul>
-							{{if .IsAdmin}}<li><a href="/admin">Admin dashboard</a></li>{{end}}
+							{{if .IsAdmin}}<li><a href="/admin">Admin dashboard{{if and .UpdateChecks .UpdateAvailable}}<span class="blip">!</span>{{end}}</a></li>{{end}}
 							<li><a href="/me/settings">Account settings</a></li>
 							<li><a href="/me/import">Import posts</a></li>
 							<li><a href="/me/export">Export</a></li>

--- a/templates/user/include/header.tmpl
+++ b/templates/user/include/header.tmpl
@@ -107,8 +107,8 @@
 		{{if not .SingleUser}}
 		<a href="/admin/users" {{if eq .Path "/admin/users"}}class="selected"{{end}}>Users</a>
 		<a href="/admin/pages" {{if eq .Path "/admin/pages"}}class="selected"{{end}}>Pages</a>
-		{{if .UpdateChecks}}<a href="/admin/updates" {{if eq .Path "/admin/updates"}}class="selected"{{end}}>Updates{{if .UpdateAvailable}}<span class="blip">!</span>{{end}}</a>{{end}}
 		{{end}}
+		{{if .UpdateChecks}}<a href="/admin/updates" {{if eq .Path "/admin/updates"}}class="selected"{{end}}>Updates{{if .UpdateAvailable}}<span class="blip">!</span>{{end}}</a>{{end}}
 		{{if not .Forest}}
 		<a href="/admin/monitor" {{if eq .Path "/admin/monitor"}}class="selected"{{end}}>Monitor</a>
 		{{end}}


### PR DESCRIPTION
This improves a few things with our automatic update checking.

 - Always show the "Updates" tab in the Admin Dashboard. Previously this didn't show on single-user instances
 - Prompt user to enable automatic version update checking on `config start` subcommand
 - Show indicator on user Admin Dashboard menu item when an update is available

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
