### PR TITLE
Fix collection / post rendering in Chorus mode

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -414,6 +414,18 @@ func (c CollectionPage) DisplayMonetization() string {
 	return displayMonetization(c.Monetization, c.Alias)
 }
 
+// UserPage provides the fields expected by the shared "user-navigation"
+// template, which otherwise assumes it's rendering for a page that embeds
+// *UserPage (e.g. the "me" backend pages).
+func (c CollectionPage) UserPage() *UserPage {
+	return &UserPage{
+		StaticPage: c.StaticPage,
+		IsAdmin:    c.IsAdmin,
+		CanInvite:  c.CanInvite,
+		CollAlias:  c.CollAlias,
+	}
+}
+
 func (c *DisplayCollection) Direction() string {
 	if c.Language == "" {
 		return "auto"

--- a/posts.go
+++ b/posts.go
@@ -303,6 +303,18 @@ func (p *Post) HasTitleLink() bool {
 	return hasLink
 }
 
+// UserPage provides the fields expected by the shared "user-navigation"
+// template, which otherwise assumes it's rendering for a page that embeds
+// *UserPage (e.g. the "me" backend pages).
+func (c CollectionPostPage) UserPage() *UserPage {
+	return &UserPage{
+		StaticPage: c.StaticPage,
+		IsAdmin:    c.IsAdmin,
+		CanInvite:  c.CanInvite,
+		CollAlias:  c.CollAlias,
+	}
+}
+
 func (c CollectionPostPage) DisplayMonetization() string {
 	if c.Collection == nil {
 		log.Info("CollectionPostPage.DisplayMonetization: c.Collection is nil")


### PR DESCRIPTION
Previously, page rendering failed on blogs and post pages when an instance was configured with our experimental Chorus mode enabled (`chorus = true`).

This fixes that by adding UserPage methods to `CollectionPage` and `CollectionPostPage` to provide the fields expected by the shared `user-navigation` template included on all "/me" path pages.

Fixes #1718

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
