### PR TITLE
ActivityPub: Fix duplicated post signature and potential HTML entities in the title

### DIFF
--- a/postrender.go
+++ b/postrender.go
@@ -105,7 +105,7 @@ func (p *Post) augmentContent(c *Collection) {
 		return
 	}
 	// Add post signatures
-	if c.Signature != "" {
+	if c.Signature != "" && !strings.HasSuffix(strings.TrimSpace(p.Content), strings.TrimSpace(c.Signature)) {
 		p.Content += "\n\n" + c.Signature
 	}
 }

--- a/posts.go
+++ b/posts.go
@@ -219,11 +219,11 @@ func (p *Post) DisplayTitle() string {
 	return t
 }
 
-// PlainDisplayTitle strips away Markdown from the generated Post's title (if
-// any), for use in places like RSS feeds and ActivityStreams objects, where
-// the raw Markdown would be unwanted.
+// PlainDisplayTitle strips away Markdown and HTML from the generated Post's
+// title (if any), for use in places like RSS feeds and ActivityStreams objects,
+// where only plain text is wanted.
 func (p *Post) PlainDisplayTitle() string {
-	if t := stripmd.Strip(p.DisplayTitle()); t != "" {
+	if t := stripmd.Strip(stripHTMLWithoutEscaping(p.DisplayTitle())); t != "" {
 		return t
 	}
 	return p.ID


### PR DESCRIPTION
This fixes two issues reported in #1675:

* Duplicated post signatures showing up in posts via ActivityPub
* HTML entities showing up in post titles in the fediverse

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
