### PR TITLE
Fix unquoted From address and phantom recipient in mailer

### DIFF
--- a/account.go
+++ b/account.go
@@ -1395,7 +1395,7 @@ func emailPasswordReset(app *App, toEmail, token string) error {
 	footerPara := "Didn't request this password reset? Your account is still safe, and you can safely ignore this email."
 
 	plainMsg := fmt.Sprintf("We received a request to reset your password on %s. Please click the following link to continue (or copy and paste it into your browser): %s/reset?t=%s\n\n%s", app.cfg.App.SiteName, app.cfg.App.Host, token, footerPara)
-	m, err := mlr.NewMessage(app.cfg.App.SiteName+" <noreply-password@"+app.cfg.Email.Domain+">", "Reset Your "+app.cfg.App.SiteName+" Password", plainMsg, fmt.Sprintf("<%s>", toEmail))
+	m, err := mlr.NewMessage(mailer.FormatAddress(app.cfg.App.SiteName, "noreply-password@"+app.cfg.Email.Domain), "Reset Your "+app.cfg.App.SiteName+" Password", plainMsg, fmt.Sprintf("<%s>", toEmail))
 	if err != nil {
 		return err
 	}
@@ -1447,7 +1447,7 @@ func loginViaEmail(app *App, alias, redirectTo string) error {
 	footerPara := "This link will only work once and expires in 15 minutes. Didn't ask us to log in? You can safely ignore this email."
 
 	plainMsg := fmt.Sprintf("Log in to %s here: %s/login?to=%s&with=%s\n\n%s", app.cfg.App.SiteName, app.cfg.App.Host, redirectTo, t, footerPara)
-	m, err := mlr.NewMessage(app.cfg.App.SiteName+" <noreply-login@"+app.cfg.Email.Domain+">", "Log in to "+app.cfg.App.SiteName, plainMsg, fmt.Sprintf("<%s>", toEmail))
+	m, err := mlr.NewMessage(mailer.FormatAddress(app.cfg.App.SiteName, "noreply-login@"+app.cfg.Email.Domain), "Log in to "+app.cfg.App.SiteName, plainMsg, fmt.Sprintf("<%s>", toEmail))
 	if err != nil {
 		return err
 	}

--- a/email.go
+++ b/email.go
@@ -346,7 +346,7 @@ Sent to %recipient.to%. Unsubscribe: ` + p.Collection.CanonicalURL() + `email/un
 	if err != nil {
 		return err
 	}
-	m, err := mlr.NewMessage(p.Collection.DisplayTitle()+" <"+p.Collection.Alias+"@"+app.cfg.Email.Domain+">", stripmd.Strip(p.DisplayTitle()), plainMsg)
+	m, err := mlr.NewMessage(mailer.FormatAddress(p.Collection.DisplayTitle(), p.Collection.Alias+"@"+app.cfg.Email.Domain), stripmd.Strip(p.DisplayTitle()), plainMsg)
 	if err != nil {
 		return err
 	}
@@ -488,7 +488,7 @@ func sendSubConfirmEmail(app *App, c *Collection, email, subID, token string) er
 ` + c.CanonicalURL() + "email/confirm/" + subID + "?t=" + token + `
 
 If you didn't subscribe to this site or you're not sure why you're getting this email, you can delete it. You won't be subscribed or receive any future emails.`
-	m, err := mlr.NewMessage(c.DisplayTitle()+" <"+c.Alias+"@"+app.cfg.Email.Domain+">", "Confirm your subscription to "+c.DisplayTitle(), plainMsg, fmt.Sprintf("<%s>", email))
+	m, err := mlr.NewMessage(mailer.FormatAddress(c.DisplayTitle(), c.Alias+"@"+app.cfg.Email.Domain), "Confirm your subscription to "+c.DisplayTitle(), plainMsg, fmt.Sprintf("<%s>", email))
 	if err != nil {
 		return err
 	}

--- a/mailer/mailer.go
+++ b/mailer/mailer.go
@@ -12,6 +12,7 @@ package mailer
 
 import (
 	"fmt"
+	netmail "net/mail"
 	"strings"
 
 	"github.com/mailgun/mailgun-go"
@@ -47,6 +48,14 @@ type (
 		vars  map[string]string
 	}
 )
+
+// FormatAddress returns a correctly quoted and escaped "name <address>"
+// string, per RFC 5322, for use as a From, To, or Reply-To header value.
+// This ensures names containing special characters (like commas) don't
+// break address parsing.
+func FormatAddress(name, address string) string {
+	return (&netmail.Address{Name: name, Address: address}).String()
+}
 
 // New creates a new Mailer from the instance's config.EmailCfg, returning an error if not properly configured.
 func New(eCfg config.EmailCfg) (*Mailer, error) {
@@ -84,7 +93,7 @@ func (m *Mailer) NewMessage(from, subject, text string, to ...string) (*Message,
 			from:       from,
 			replyTo:    "",
 			subject:    subject,
-			recipients: make([]Recipient, len(to)),
+			recipients: make([]Recipient, 0, len(to)),
 			html:       "",
 			text:       text,
 		}


### PR DESCRIPTION
Blog names containing commas or other RFC 5322 special characters broke the SMTP "From" header, silently discarding the recipient too and preventing any email from sending. This adds mailer.FormatAddress to properly quote/escape display names.

Also fix mailer.NewMessage pre-allocating a phantom empty-address recipient alongside every single-recipient send, which caused a spurious "No recipient specified" error to be logged on every password reset, login link, and subscription confirmation email. (#1545, #1552)

Fixes #1551

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
