### PR TITLE
Validate invite codes on /auth/signup with closed registrations

### DIFF
--- a/unregisteredusers.go
+++ b/unregisteredusers.go
@@ -44,8 +44,15 @@ func handleWebSignup(app *App, w http.ResponseWriter, r *http.Request) error {
 			return ErrBadFormData
 		}
 	}
-	if !app.cfg.App.OpenRegistration && ur.InviteCode == "" {
-		return impart.HTTPError{http.StatusForbidden, "Registration is closed"}
+	if !app.cfg.App.OpenRegistration {
+		// Registrations are closed, so an invite is required. Verify the given
+		// code actually exists and is still usable -- otherwise any non-empty
+		// value would be enough to create an account. Mirrors the check the
+		// OAuth signup flow already performs in viewOauthCallback().
+		i, err := app.db.GetUserInvite(ur.InviteCode)
+		if err != nil || !i.Active(app.db) {
+			return impart.HTTPError{http.StatusForbidden, "Registration is closed"}
+		}
 	}
 	ur.Web = true
 	ur.Normalize = true


### PR DESCRIPTION
Despite previous fixing efforts, an user can still by created on a closed instance by providing a non-empty invite code to /auth/sighup - nothing validates the code.

Note: the CreateInvitedUser() in signupWithRegistration() is purely cosmetic, it just logs the invite code in DB.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
