### PR TITLE
Fix password-protected blogs not unlocking after cookie expires

### DIFF
--- a/collections.go
+++ b/collections.go
@@ -1409,12 +1409,14 @@ func handleWebCollectionUnlock(app *App, w http.ResponseWriter, r *http.Request)
 
 	// Success; set cookie
 	session, err := app.sessionStore.Get(r, blogPassCookieName)
-	if err == nil {
-		session.Values[readReq.Alias] = true
-		err = session.Save(r, w)
-		if err != nil {
-			log.Error("Didn't save unlocked blog '%s': %v", readReq.Alias, err)
-		}
+	if err != nil {
+		// The cookie should still save, even if there's an error.
+		log.Error("Getting blog password cookie for '%s': %v; ignoring", readReq.Alias, err)
+	}
+	session.Values[readReq.Alias] = true
+	err = session.Save(r, w)
+	if err != nil {
+		log.Error("Didn't save unlocked blog '%s': %v", readReq.Alias, err)
 	}
 
 	next := "/" + readReq.Next


### PR DESCRIPTION
Previously, we would only set a new cookie to replace the older, expired one if there was absolutely no error. Instead, we now safely ignore any errors and attempt to re-set the cookie, which should fix this.

Fixes #298

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
