### PR TITLE
Fix unreachable posts with slug "meta" or "edit" multi-user mode

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -825,17 +825,13 @@ func existingPost(app *App, w http.ResponseWriter, r *http.Request) error {
 
 	addSessionFlash(app, w, r, "Changes saved.", nil)
 	collectionAlias := vars["alias"]
-	redirect := "/" + postID + "/meta"
+	redirect := "/d/" + postID + "/edit/meta"
 	if collectionAlias != "" {
 		collPre := "/" + collectionAlias
 		if app.cfg.App.SingleUser {
 			collPre = ""
 		}
 		redirect = collPre + "/" + pRes.Slug.String + "/edit/meta"
-	} else {
-		if app.cfg.App.SingleUser {
-			redirect = "/d" + redirect
-		}
 	}
 	w.Header().Set("Location", redirect)
 	w.WriteHeader(http.StatusFound)

--- a/routes.go
+++ b/routes.go
@@ -201,9 +201,8 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 		write.HandleFunc("/new", handler.Web(handleViewPad, UserLevelUser)).Methods("GET")
 	}
 
-	// All the existing stuff
-	write.HandleFunc(draftEditPrefix+"/{action}/edit", handler.Web(handleViewPad, UserLevelUser)).Methods("GET")
-	write.HandleFunc(draftEditPrefix+"/{action}/meta", handler.Web(handleViewMeta, UserLevelUser)).Methods("GET")
+	write.HandleFunc("/d/{action}/edit", handler.Web(handleViewPad, UserLevelUser)).Methods("GET")
+	write.HandleFunc("/d/{action}/edit/meta", handler.Web(handleViewMeta, UserLevelUser)).Methods("GET")
 	// Collections
 	if apper.App().cfg.App.SingleUser {
 		RouteCollections(handler, write.PathPrefix("/").Subrouter())

--- a/static/js/posts.js
+++ b/static/js/posts.js
@@ -203,7 +203,7 @@ var createPostEl = function(post, owned, singleUser) {
 		posted = getFormattedDate(new Date(post.created))
 	}
 	var hasDraft = H.exists('draft' + post.id);
-	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="' + postLink + '/edit">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
+	$post.innerHTML += '<h4><date>' + posted + '</date> <a class="action" href="/d/' + post.id + '/edit">edit' + (hasDraft ? 'ed' : '') + '</a> <a class="delete action" href="/' + post.id + '" onclick="delPost(event, \'' + post.id + '\'' + (owned === true ? ', true' : '') + ')">delete</a> '+movePostHTML(post.id)+'</h4>';
 
 	if (post.error) {
 		$post.innerHTML += '<p class="error"><strong>Sync error:</strong> ' + post.error + ' <nav><a href="#" onclick="localPosts.dismissError(event, this)">dismiss</a> <a href="#" onclick="localPosts.deletePost(event, this, \''+post.id+'\')">remove post</a></nav></p>';

--- a/templates/bare.tmpl
+++ b/templates/bare.tmpl
@@ -30,7 +30,7 @@
 			</div>
 			<noscript style="margin-left: 2em;"><strong>NOTE</strong>: for now, you'll need JavaScript enabled to post.</noscript>
 			<div id="belt">
-				{{if .Editing}}<div class="tool hidden if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit/meta{{else}}/{{if .SingleUser}}d/{{end}}{{.Post.Id}}/meta{{end}}" title="Edit post metadata" id="edit-meta"><img class="ic-24dp" src="/img/ic_info_dark@2x.png" /></a></div>{{end}}
+				{{if .Editing}}<div class="tool hidden if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit/meta{{else}}/d/{{.Post.Id}}/edit/meta{{end}}" title="Edit post metadata" id="edit-meta"><img class="ic-24dp" src="/img/ic_info_dark@2x.png" /></a></div>{{end}}
 				<div class="tool"><button title="Publish your writing" id="publish" style="font-weight: bold">Post</button></div>
 			</div>
 		</header>

--- a/templates/classic.tmpl
+++ b/templates/classic.tmpl
@@ -64,7 +64,7 @@
 			</div>
 			<noscript style="margin-left: 2em;"><strong>NOTE</strong>: for now, you'll need JavaScript enabled to post.</noscript>
 			<div id="belt">
-				{{if .Editing}}<div class="tool hidden if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit/meta{{else}}/{{if .SingleUser}}d/{{end}}{{.Post.Id}}/meta{{end}}" title="Edit post metadata" id="edit-meta"><img class="ic-24dp" src="/img/ic_info_dark@2x.png" /></a></div>{{end}}
+				{{if .Editing}}<div class="tool hidden if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit/meta{{else}}/d/{{.Post.Id}}/edit/meta{{end}}" title="Edit post metadata" id="edit-meta"><img class="ic-24dp" src="/img/ic_info_dark@2x.png" /></a></div>{{end}}
 				<div class="tool hidden if-room room-2"><a href="#theme" title="Toggle theme" id="toggle-theme"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a></div>
 				<div class="tool if-room room-1"><a href="{{if not .User}}/pad/posts{{else}}/me/posts/{{end}}" title="View posts" id="view-posts"><img class="ic-24dp" src="/img/ic_list_dark@2x.png" /></a></div>
 				<div class="tool"><a href="#publish" title="Publish" id="publish"><img class="ic-24dp" src="/img/ic_send_dark@2x.png" /></a></div>

--- a/templates/edit-meta.tmpl
+++ b/templates/edit-meta.tmpl
@@ -45,7 +45,7 @@
 				</ul></nav>
 			</div>
 			<div id="belt">
-				<div class="tool if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit{{else}}/{{.Post.Id}}/edit{{end}}" title="Edit post" id="edit"><img class="ic-24dp" src="/img/ic_edit_dark@2x.png" /></a></div>
+				<div class="tool if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit{{else}}/d/{{.Post.Id}}/edit{{end}}" title="Edit post" id="edit"><img class="ic-24dp" src="/img/ic_edit_dark@2x.png" /></a></div>
 				<div class="tool if-room room-2"><a href="#theme" title="Toggle theme" id="toggle-theme"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a></div>
 				<div class="tool if-room room-1"><a href="/me/posts/" title="View posts" id="view-posts"><img class="ic-24dp" src="/img/ic_list_dark@2x.png" /></a></div>
 			</div>

--- a/templates/pad.tmpl
+++ b/templates/pad.tmpl
@@ -64,7 +64,7 @@
 			</div>
 			<noscript style="margin-left: 2em;"><strong>NOTE</strong>: for now, you'll need JavaScript enabled to post.</noscript>
 			<div id="belt">
-				{{if .Editing}}<div class="tool hidden if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit/meta{{else}}/{{if .SingleUser}}d/{{end}}{{.Post.Id}}/meta{{end}}" title="Edit post metadata" id="edit-meta"><img class="ic-24dp" src="/img/ic_info_dark@2x.png" /></a></div>{{end}}
+				{{if .Editing}}<div class="tool hidden if-room"><a href="{{if .EditCollection}}{{.EditCollection.CanonicalURL}}{{.Post.Slug}}/edit/meta{{else}}/d/{{.Post.Id}}/edit/meta{{end}}" title="Edit post metadata" id="edit-meta"><img class="ic-24dp" src="/img/ic_info_dark@2x.png" /></a></div>{{end}}
 				<div class="tool hidden if-room room-2"><a href="#theme" title="Toggle theme" id="toggle-theme"><img class="ic-24dp" src="/img/ic_brightness_dark@2x.png" /></a></div>
 				<div class="tool if-room room-1"><a href="{{if not .User}}/pad/posts{{else}}/me/posts/{{end}}" title="View posts" id="view-posts"><img class="ic-24dp" src="/img/ic_list_dark@2x.png" /></a></div>
 				<div class="tool if-room room-1"><a href="#" title="Preview" id="toggle-preview"><img class="ic-24dp" src="/img/ic_preview_dark@2x.png" /></a></div>

--- a/templates/post.tmpl
+++ b/templates/post.tmpl
@@ -43,7 +43,7 @@
 				{{if .IsCode}}<a href="/{{.ID}}.txt" rel="noindex" dir="{{.Direction}}">View raw</a>{{end}}
 				{{ if .Username }}
 				{{if .IsOwner}}
-				<a href="/{{if .SingleUser}}d/{{end}}{{.ID}}/edit" dir="{{.Direction}}">Edit</a>
+				<a href="/d/{{.ID}}/edit" dir="{{.Direction}}">Edit</a>
 				{{end}}
 				<a class="xtra-feature dash-nav" href="/me/posts/" dir="{{.Direction}}">Drafts</a>
 				{{ end }}
@@ -89,7 +89,7 @@
 		var $nav = document.getElementsByTagName('nav')[0];
 		for (var i=0; i<posts.length; i++) {
 			if (posts[i].id == "{{.ID}}") {
-				$nav.innerHTML = $nav.innerHTML + '<a class="xtra-feature" href="/edit/{{.ID}}" dir="{{.Direction}}">Edit</a>';
+				$nav.innerHTML = $nav.innerHTML + '<a class="xtra-feature" href="/d/{{.ID}}/edit" dir="{{.Direction}}">Edit</a>';
 				var $ownerVis = document.querySelectorAll('.owner-visible');
 				for (var i=0; i<$ownerVis.length; i++) {
 					$ownerVis[i].classList.remove('owner-visible');

--- a/templates/user/articles.tmpl
+++ b/templates/user/articles.tmpl
@@ -29,7 +29,7 @@
 		<h3><a href="/{{if $.SingleUser}}d/{{end}}{{.ID}}" itemprop="url">{{.DisplayTitle}}</a></h3>
 		<h4>
 			<date datetime="{{.Created}}" pubdate itemprop="datePublished" content="{{.Created}}">{{.DisplayDate}}</date>
-			<a class="action" href="/{{if $.SingleUser}}d/{{end}}{{.ID}}/edit">edit</a>
+			<a class="action" href="/d/{{.ID}}/edit">edit</a>
 			<a class="delete action" href="/{{.ID}}" onclick="delPost(event, '{{.ID}}', true)">delete</a>
 			{{ if $.Collections }}
 			{{if gt (len $.Collections) 1}}<div class="action flat-select">


### PR DESCRIPTION
In multi-user mode the draft-editing routes `/{action}/edit` and `/{action}/meta` would always take precedence over any collection post whose slug was "edit" or "meta", so /myblog/meta rendered "This page is missing" instead of the post.

This moves draft editing to the `/d/` path in both single- and multi-user mode, and normalizes the metadata path to `/d/{action}/edit/meta` to match the collection editing path, while keeping post *viewing* URLs unchanged.

**Note**: though this shouldn't be a large problem, any previous "edit" or "meta" bookmarks will need to be updated to the new paths.

This also fixes a dead edit link in post.tmpl that pointed at `/edit/{id}`, for which no route exists.

Fixes #278

_This still needs more extensive testing._

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
