### PR TITLE
Include image alt text in fediverse attachment data

### DIFF
--- a/posts.go
+++ b/posts.go
@@ -1290,8 +1290,13 @@ func (p *PublicPost) ActivityObject(app *App) *activitystreams.Object {
 		}
 	}
 	if len(p.Images) > 0 {
+		altText := extractImageAltText(p.Content)
 		for _, i := range p.Images {
-			o.Attachment = append(o.Attachment, activitystreams.NewImageAttachment(i))
+			img := activitystreams.NewImageAttachment(i)
+			if alt, ok := altText[i]; ok {
+				img.Name = alt
+			}
+			o.Attachment = append(o.Attachment, img)
 		}
 	}
 	// Find mentioned users
@@ -1755,10 +1760,27 @@ func (rp *RawPost) Updated8601() string {
 	return rp.Updated.Format("2006-01-02T15:04:05Z")
 }
 
-var imageURLRegex = regexp.MustCompile(`(?i)[^ ]+\.(gif|png|jpg|jpeg|avif|avifs|webp|jxl|image)$`)
+var (
+	imageURLRegex      = regexp.MustCompile(`(?i)[^ ]+\.(gif|png|jpg|jpeg|avif|avifs|webp|jxl|image)$`)
+	imageMarkdownRegex = regexp.MustCompile(`!\[([^\]]*)\]\(\s*(\S+?)(?:\s+"[^"]*")?\s*\)`)
+)
 
 func (p *Post) extractImages() {
 	p.Images = extractImages(p.Content)
+}
+
+// extractImageAltText maps image URLs to their Markdown alt text for any
+// images written with Markdown image syntax in content.
+func extractImageAltText(content string) map[string]string {
+	alts := map[string]string{}
+	for _, m := range imageMarkdownRegex.FindAllStringSubmatch(content, -1) {
+		alt := strings.TrimSpace(m[1])
+		if alt == "" {
+			continue
+		}
+		alts[m[2]] = alt
+	}
+	return alts
 }
 
 func extractImages(content string) []string {

--- a/posts_test.go
+++ b/posts_test.go
@@ -8,19 +8,18 @@
  * in the LICENSE file in this source code package.
  */
 
-package writefreely_test
+package writefreely
 
 import (
 	"testing"
 
 	"github.com/guregu/null/zero"
 	"github.com/stretchr/testify/assert"
-	"github.com/writefreely/writefreely"
 )
 
 func TestPostSummary(t *testing.T) {
 	testCases := map[string]struct {
-		given    writefreely.Post
+		given    Post
 		expected string
 	}{
 		"no special chars":          {givenPost("Content."), "Content."},
@@ -40,6 +39,55 @@ lines.`), "Content in multiple lines."},
 	}
 }
 
-func givenPost(content string) writefreely.Post {
-	return writefreely.Post{Title: zero.StringFrom("Title"), Content: content}
+func givenPost(content string) Post {
+	return Post{Title: zero.StringFrom("Title"), Content: content}
+}
+
+func TestExtractImageAltText(t *testing.T) {
+	testCases := map[string]struct {
+		content  string
+		expected map[string]string
+	}{
+		"basic image": {
+			"![a cat](https://example.com/cat.png)",
+			map[string]string{"https://example.com/cat.png": "a cat"},
+		},
+		"image with title": {
+			`![a cat](https://example.com/cat.png "Kitty")`,
+			map[string]string{"https://example.com/cat.png": "a cat"},
+		},
+		"empty alt text is omitted": {
+			"![](https://example.com/cat.png)",
+			map[string]string{},
+		},
+		"whitespace-only alt text is omitted": {
+			"![   ](https://example.com/cat.png)",
+			map[string]string{},
+		},
+		"alt text is trimmed": {
+			"![  a cat  ](https://example.com/cat.png)",
+			map[string]string{"https://example.com/cat.png": "a cat"},
+		},
+		"multiple images": {
+			"![cat](https://example.com/cat.png) and ![dog](https://example.com/dog.jpg)",
+			map[string]string{
+				"https://example.com/cat.png": "cat",
+				"https://example.com/dog.jpg": "dog",
+			},
+		},
+		"bare url has no alt text": {
+			"See https://example.com/cat.png",
+			map[string]string{},
+		},
+		"non-image markdown link ignored": {
+			"[a link](https://example.com/page)",
+			map[string]string{},
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, test.expected, extractImageAltText(test.content))
+		})
+	}
 }


### PR DESCRIPTION
This parses out any alt text found in Markdown images included in a post, and adds the text as the image attachment's `name` property, so it shows up across the fediverse, as well.

Fixes #698

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
