### PR TITLE
Normalize usernames on signups via OAuth

### DIFF
--- a/oauth_signup.go
+++ b/oauth_signup.go
@@ -22,6 +22,7 @@ import (
 	"github.com/writeas/impart"
 	"github.com/writeas/web-core/auth"
 	"github.com/writeas/web-core/log"
+	"github.com/writefreely/writefreely/author"
 	"github.com/writefreely/writefreely/page"
 )
 
@@ -117,7 +118,9 @@ func (h oauthHandler) viewOauthSignup(app *App, w http.ResponseWriter, r *http.R
 		}
 	}
 	newUser := &User{
-		Username:   r.FormValue(oauthParamUsername),
+		// Normalize the username into a valid slug, just like normal registration, so the collection alias is always
+		// lowercase
+		Username:   getSlug(r.FormValue(oauthParamUsername), ""),
 		HashedPass: hashedPass,
 		HasPass:    hasPass,
 		Email:      prepareUserEmail(r.FormValue(oauthParamEmail), h.EmailKey),
@@ -153,12 +156,16 @@ func (h oauthHandler) viewOauthSignup(app *App, w http.ResponseWriter, r *http.R
 }
 
 func (h oauthHandler) validateOauthSignup(r *http.Request) error {
-	username := r.FormValue(oauthParamUsername)
+	// Validate the normalized username, since that's what we'll actually store as the user's name and collection alias
+	username := getSlug(r.FormValue(oauthParamUsername), "")
 	if len(username) < h.Config.App.MinUsernameLen {
 		return impart.HTTPError{Status: http.StatusBadRequest, Message: "Username is too short."}
 	}
 	if len(username) > 100 {
 		return impart.HTTPError{Status: http.StatusBadRequest, Message: "Username is too long."}
+	}
+	if !author.IsValidUsername(h.Config, username) {
+		return impart.HTTPError{Status: http.StatusPreconditionFailed, Message: "Username is reserved or isn't valid. It must be at least 3 characters long, and can only include letters, numbers, and hyphens."}
 	}
 	collTitle := r.FormValue(oauthParamAlias)
 	if len(collTitle) == 0 {

--- a/signup_test.go
+++ b/signup_test.go
@@ -386,3 +386,55 @@ func TestOAuthSignupCannotSwapInviteCodeWithoutInvalidatingSignature(t *testing.
 	}
 	assert.False(t, userExists(t, app, username))
 }
+
+// TestOAuthSignupNormalizesUsername is regression coverage for #648 and #844:
+// usernames created via OAuth must be run through the same slug normalization as
+// normal registration, so the resulting collection alias is always lowercase.
+// Otherwise the blog 404s, since collection URLs are redirected to their
+// lowercase form on request but no matching (lowercase) alias exists.
+func TestOAuthSignupNormalizesUsername(t *testing.T) {
+	app := newSignupTestApp(t)
+	app.cfg.App.OpenRegistration = true
+	h := newTestOauthHandler(app)
+
+	const submitted = "MixedCaseUser"
+	const normalized = "mixedcaseuser"
+
+	tp := oauthSignupPageParams{
+		AccessToken:     "tok-mixed",
+		TokenUsername:   submitted,
+		TokenAlias:      submitted,
+		TokenRemoteUser: "remote-mixed",
+		ClientID:        "client1",
+		Provider:        "generic",
+	}
+	sig := signOauthParams(app.cfg.Server.HashSeed, tp)
+
+	form := url.Values{}
+	form.Set(oauthParamAccessToken, tp.AccessToken)
+	form.Set(oauthParamTokenUsername, tp.TokenUsername)
+	form.Set(oauthParamTokenAlias, tp.TokenAlias)
+	form.Set(oauthParamTokenRemoteUserID, tp.TokenRemoteUser)
+	form.Set(oauthParamClientID, tp.ClientID)
+	form.Set(oauthParamProvider, tp.Provider)
+	form.Set(oauthParamHash, sig)
+	form.Set(oauthParamUsername, submitted)
+
+	req := httptest.NewRequest("POST", "/oauth/signup", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	if err := h.viewOauthSignup(app, w, req); err != nil {
+		t.Fatalf("expected oauth signup to succeed, got error: %v", err)
+	}
+
+	assert.True(t, userExists(t, app, normalized), "user should be stored with a lowercased username")
+	assert.False(t, userExists(t, app, submitted), "user should not be stored with the raw mixed-case username")
+
+	var alias string
+	err := app.db.QueryRow("SELECT alias FROM collections WHERE alias = ?", normalized).Scan(&alias)
+	if err != nil {
+		t.Fatalf("expected collection with lowercased alias %q: %v", normalized, err)
+	}
+	assert.Equal(t, normalized, alias, "collection alias must be lowercase to be reachable")
+}


### PR DESCRIPTION
This ensures, for example, new users don't get created with uppercase usernames that later cause issues when we automatically redirect to lowercase equivalents, resulting in 404s.

It also adds an `author.IsValidUsername` check when registering via OAuth.

**Note**: this does _not_ automatically fix current users who might've ended up with a faulty username.

This fixes #648 #844

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
