### PR TITLE
Output more helpful error messages at startup

### DIFF
--- a/app.go
+++ b/app.go
@@ -620,6 +620,17 @@ func ConnectToDatabase(app *App) error {
 		}
 	}
 
+	// Ensure the database schema is up-to-date
+	var dbVer int
+	err = app.db.QueryRow("SELECT MAX(version) FROM appmigrations").Scan(&dbVer)
+	if err != nil {
+		log.Error("Unable to read migrations version: %v", err)
+	} else if dbVer < migrations.CurrentVer() {
+		log.Info("+--------------------------------------------------------------------------+")
+		log.Info("| IMPORTANT! There are pending migrations (%d). Run: writefreely db migrate |", migrations.CurrentVer()-dbVer)
+		log.Info("+--------------------------------------------------------------------------+")
+	}
+
 	return nil
 }
 

--- a/app.go
+++ b/app.go
@@ -406,6 +406,17 @@ var fileRegex = regexp.MustCompile("/([^/]*\\.[^/]*)$")
 func Initialize(apper Apper, debug bool) (*App, error) {
 	debugging = debug
 
+	// Ensure a configuration file exists first, for a nicer error message
+	if _, err := os.Stat(apper.App().cfgFile); os.IsNotExist(err) {
+		flagOpt := ""
+		loc := " yet"
+		if apper.App().cfgFile != config.FileName {
+			flagOpt = " -c " + apper.App().cfgFile
+			loc = " at " + apper.App().cfgFile
+		}
+		return nil, fmt.Errorf("No configuration file%s. To create, run:\n  writefreely%s config start", loc, flagOpt)
+	}
+
 	apper.LoadConfig()
 
 	// Load templates

--- a/keys.go
+++ b/keys.go
@@ -11,6 +11,7 @@
 package writefreely
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -34,6 +35,10 @@ func InitKeys(apper Apper) error {
 	log.Info("Loading encryption keys...")
 	err := apper.LoadKeys()
 	if err != nil {
+		if os.IsNotExist(err) {
+			keysPath := filepath.Join(apper.App().cfg.Server.KeysParentDir, keysDir)
+			return fmt.Errorf("Missing encryption keys at %s. To create, run:\n  writefreely keys generate", keysPath)
+		}
 		return err
 	}
 	return nil

--- a/templates.go
+++ b/templates.go
@@ -12,6 +12,7 @@ package writefreely
 
 import (
 	"errors"
+	"fmt"
 	"html/template"
 	"io"
 	"net/http"
@@ -116,12 +117,25 @@ func initUserPage(parentDir, path, key string) {
 	))
 }
 
+// missingDirError returns a helpful error when required templates/pages directory doesn't exist.
+func missingDirError(name, dir string, err error) error {
+	if !os.IsNotExist(err) {
+		return err
+	}
+	abs, absErr := filepath.Abs(dir)
+	if absErr != nil {
+		abs = dir
+	}
+	return fmt.Errorf("unable to find %s directory, expected at %q", name, abs)
+}
+
 // InitTemplates loads all template files from the configured parent dir.
 func InitTemplates(cfg *config.Config) error {
 	log.Info("Loading templates...")
-	tmplFiles, err := os.ReadDir(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir))
+	templatesPath := filepath.Join(cfg.Server.TemplatesParentDir, templatesDir)
+	tmplFiles, err := os.ReadDir(templatesPath)
 	if err != nil {
-		return err
+		return missingDirError(templatesDir, templatesPath, err)
 	}
 
 	for _, f := range tmplFiles {
@@ -134,8 +148,12 @@ func InitTemplates(cfg *config.Config) error {
 
 	log.Info("Loading pages...")
 	// Initialize all static pages that use the base template
-	err = filepath.Walk(filepath.Join(cfg.Server.PagesParentDir, pagesDir), func(path string, i os.FileInfo, err error) error {
+	pagesPath := filepath.Join(cfg.Server.PagesParentDir, pagesDir)
+	err = filepath.Walk(pagesPath, func(path string, i os.FileInfo, err error) error {
 		if err != nil {
+			if path == pagesPath {
+				return missingDirError(pagesDir, pagesPath, err)
+			}
 			return err
 		}
 		if !i.IsDir() && !strings.HasPrefix(i.Name(), ".") {
@@ -151,8 +169,12 @@ func InitTemplates(cfg *config.Config) error {
 
 	log.Info("Loading user pages...")
 	// Initialize all user pages that use base templates
-	err = filepath.Walk(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir, "user"), func(path string, f os.FileInfo, err error) error {
+	userPath := filepath.Join(cfg.Server.TemplatesParentDir, templatesDir, "user")
+	err = filepath.Walk(userPath, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
+			if path == userPath {
+				return missingDirError(filepath.Join(templatesDir, "user"), userPath, err)
+			}
 			return err
 		}
 		if !f.IsDir() && !strings.HasPrefix(f.Name(), ".") {


### PR DESCRIPTION
Upon starting the WriteFreely server, this checks a few things along the way and instructs the admin to run different setup commands to fix the issue, if needed:

* No `templates` or `pages` directories found (fixes #757)
* Missing encryption keys / `keys` directory
* Missing configuration file
* If any database migrations need to run (a non-exiting notice)

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
