### PR TITLE
Support compiling templates and static assets into binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,17 @@ DOCKERCMD=docker
 IMAGE_NAME=writeas/writefreely
 TMPBIN=./tmp
 
-# Build tags used for normal (disk-based) builds. Static assets -- everything
-# under static/, except file-based overrides like static/local/custom.css --
-# are read from disk at runtime, so `make ui` / editing static/ is picked up
+# Build tags used for normal (disk-based) builds. static/, templates/, and
+# pages/ -- except file-based overrides like static/local/custom.css -- are
+# read from disk at runtime, so `make ui` / editing those dirs is picked up
 # without a rebuild.
 TAGS=netgo sqlite
 NOSQLITE_TAGS=netgo
 
-# Adding the `embed` tag compiles the contents of static/ into the binary
+# Adding the `embed` tag compiles the contents of static/, templates/, and
+# pages/ into the binary. File-based overrides are still read from disk and
+# take precedence over their embedded counterparts. This is what release
+# builds use, so they produce a single self-contained binary.
 EMBED_TAGS=$(TAGS) embed
 
 all : build
@@ -31,8 +34,9 @@ ci: deps
 build: deps
 	cd cmd/writefreely; $(GOBUILD) -v -tags='$(TAGS)'
 
-# build-embed produces a binary with static assets embedded, for locally
-# testing embedded release builds without running the full `release` target.
+# build-embed produces a binary with static/templates/pages embedded, for
+# locally testing embedded release builds without running the full `release`
+# target.
 build-embed: deps
 	cd cmd/writefreely; $(GOBUILD) -v -tags='$(EMBED_TAGS)'
 
@@ -103,12 +107,21 @@ install : build
 	cmd/writefreely/$(BINARY_NAME) --init-db
 	cd less/; $(MAKE) install $(MFLAGS)
 
+# static/, templates/, and pages/ are compiled into each release binary via
+# the `embed` build tag (see EMBED_TAGS above), so none of them are shipped
+# as loose files alongside the binary anymore. File-based overrides like
+# static/local/custom.css still work: an admin can create the relevant
+# directory next to the binary and it takes precedence over the embedded
+# copy.
+#
+# Because `embed` reads templates/ from source rather than from $(BUILDPATH),
+# the CSS cache-busting rewrite has to run against the tracked templates/
+# directory itself instead of a disposable copy. It's reverted via
+# `git checkout` once every platform binary has been built.
 release : clean ui
 	mkdir -p $(BUILDPATH)
-	rsync -av --exclude=".*" templates $(BUILDPATH)
-	rsync -av --exclude=".*" pages $(BUILDPATH)
-	scripts/invalidate-css.sh $(BUILDPATH)
 	mkdir $(BUILDPATH)/keys
+	scripts/invalidate-css.sh .
 	$(MAKE) build-linux TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-linux-amd64 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
@@ -137,12 +150,11 @@ release : clean ui
 	mv build/$(BINARY_NAME)-windows-4.0-amd64.exe $(BUILDPATH)/$(BINARY_NAME).exe
 	cd build; zip -r ../$(BINARY_NAME)_$(GITREV)_windows_amd64.zip ./$(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME).exe
+	git checkout -- templates
 
 # This assumes you're on linux/amd64
 release-linux : clean ui
 	mkdir -p $(BUILDPATH)
-	cp -r templates $(BUILDPATH)
-	cp -r pages $(BUILDPATH)
 	mkdir $(BUILDPATH)/keys
 	$(MAKE) build-no-sqlite NOSQLITE_TAGS='netgo embed'
 	mv cmd/writefreely/$(BINARY_NAME) $(BUILDPATH)/$(BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -13,58 +13,73 @@ DOCKERCMD=docker
 IMAGE_NAME=writeas/writefreely
 TMPBIN=./tmp
 
+# Build tags used for normal (disk-based) builds. Static assets -- everything
+# under static/, except file-based overrides like static/local/custom.css --
+# are read from disk at runtime, so `make ui` / editing static/ is picked up
+# without a rebuild.
+TAGS=netgo sqlite
+NOSQLITE_TAGS=netgo
+
+# Adding the `embed` tag compiles the contents of static/ into the binary
+EMBED_TAGS=$(TAGS) embed
+
 all : build
 
 ci: deps
 	cd cmd/writefreely; $(GOBUILD) -v
 
 build: deps
-	cd cmd/writefreely; $(GOBUILD) -v -tags='netgo sqlite'
+	cd cmd/writefreely; $(GOBUILD) -v -tags='$(TAGS)'
+
+# build-embed produces a binary with static assets embedded, for locally
+# testing embedded release builds without running the full `release` target.
+build-embed: deps
+	cd cmd/writefreely; $(GOBUILD) -v -tags='$(EMBED_TAGS)'
 
 build-no-sqlite: deps-no-sqlite
-	cd cmd/writefreely; $(GOBUILD) -v -tags='netgo' -o $(BINARY_NAME)
+	cd cmd/writefreely; $(GOBUILD) -v -tags='$(NOSQLITE_TAGS)' -o $(BINARY_NAME)
 
 build-linux: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOCMD) install src.techknowlogick.com/xgo@latest; \
 	fi
-	xgo --targets=linux/amd64, -dest build/ $(LDFLAGS) -tags='netgo sqlite' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
+	xgo --targets=linux/amd64, -dest build/ $(LDFLAGS) -tags='$(TAGS)' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
 
 build-windows: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOCMD) install src.techknowlogick.com/xgo@latest; \
 	fi
-	xgo --targets=windows/amd64, -dest build/ $(LDFLAGS) -tags='netgo sqlite' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
+	xgo --targets=windows/amd64, -dest build/ $(LDFLAGS) -tags='$(TAGS)' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
 
 build-darwin: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOCMD) install src.techknowlogick.com/xgo@latest; \
 	fi
-	xgo --targets=darwin/amd64, -dest build/ $(BASELDFLAGS) -tags='netgo sqlite' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
+	xgo --targets=darwin/amd64, -dest build/ $(BASELDFLAGS) -tags='$(TAGS)' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
 
 build-darwin-arm64: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOCMD) install src.techknowlogick.com/xgo@latest; \
 	fi
-	xgo --targets=darwin/arm64, -dest build/ $(BASELDFLAGS) -tags='netgo sqlite' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
+	xgo --targets=darwin/arm64, -dest build/ $(BASELDFLAGS) -tags='$(TAGS)' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
 
 build-arm6: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOCMD) install src.techknowlogick.com/xgo@latest; \
 	fi
-	xgo --targets=linux/arm-6, -dest build/ $(LDFLAGS) -tags='netgo sqlite' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
+	xgo --targets=linux/arm-6, -dest build/ $(LDFLAGS) -tags='$(TAGS)' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
 
 build-arm7: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOCMD) install src.techknowlogick.com/xgo@latest; \
 	fi
-	xgo --targets=linux/arm-7, -dest build/ $(LDFLAGS) -tags='netgo sqlite' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
+	xgo --targets=linux/arm-7, -dest build/ $(LDFLAGS) -tags='$(TAGS)' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
 
 build-arm64: deps
 	@hash xgo > /dev/null 2>&1; if [ $$? -ne 0 ]; then \
 		$(GOCMD) install src.techknowlogick.com/xgo@latest; \
 	fi
-	xgo --targets=linux/arm64, -dest build/ $(LDFLAGS) -tags='netgo sqlite' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
+	xgo --targets=linux/arm64, -dest build/ $(LDFLAGS) -tags='$(TAGS)' -go go-1.25.x -out writefreely -pkg ./cmd/writefreely .
 
 build-docker :
 	$(DOCKERCMD) build -t $(IMAGE_NAME):latest -t $(IMAGE_NAME):$(GITREV) .
@@ -73,7 +88,7 @@ test:
 	$(GOTEST) -v ./...
 
 run:
-	$(GOINSTALL) -tags='netgo sqlite' ./...
+	$(GOINSTALL) -tags='$(TAGS)' ./...
 	$(BINARY_NAME) --debug
 
 deps :
@@ -92,35 +107,33 @@ release : clean ui
 	mkdir -p $(BUILDPATH)
 	rsync -av --exclude=".*" templates $(BUILDPATH)
 	rsync -av --exclude=".*" pages $(BUILDPATH)
-	rsync -av --exclude=".*" static $(BUILDPATH)
-	rm -r $(BUILDPATH)/static/local
 	scripts/invalidate-css.sh $(BUILDPATH)
 	mkdir $(BUILDPATH)/keys
-	$(MAKE) build-linux
+	$(MAKE) build-linux TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-linux-amd64 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
-	$(MAKE) build-arm6
+	$(MAKE) build-arm6 TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-linux-arm-6 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_arm6.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
-	$(MAKE) build-arm7
+	$(MAKE) build-arm7 TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-linux-arm-7 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_arm7.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
-	$(MAKE) build-arm64
+	$(MAKE) build-arm64 TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-linux-arm64 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_arm64.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
-	$(MAKE) build-darwin
+	$(MAKE) build-darwin TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-darwin-10.12-amd64 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_macos_amd64.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
-	$(MAKE) build-darwin-arm64
+	$(MAKE) build-darwin-arm64 TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-darwin-10.12-arm64 $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_macos_arm64.tar.gz -C build $(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME)
-	$(MAKE) build-windows
+	$(MAKE) build-windows TAGS='$(EMBED_TAGS)'
 	mv build/$(BINARY_NAME)-windows-4.0-amd64.exe $(BUILDPATH)/$(BINARY_NAME).exe
 	cd build; zip -r ../$(BINARY_NAME)_$(GITREV)_windows_amd64.zip ./$(BINARY_NAME)
 	rm $(BUILDPATH)/$(BINARY_NAME).exe
@@ -130,9 +143,8 @@ release-linux : clean ui
 	mkdir -p $(BUILDPATH)
 	cp -r templates $(BUILDPATH)
 	cp -r pages $(BUILDPATH)
-	cp -r static $(BUILDPATH)
 	mkdir $(BUILDPATH)/keys
-	$(MAKE) build-no-sqlite
+	$(MAKE) build-no-sqlite NOSQLITE_TAGS='netgo embed'
 	mv cmd/writefreely/$(BINARY_NAME) $(BUILDPATH)/$(BINARY_NAME)
 	tar -cvzf $(BINARY_NAME)_$(GITREV)_linux_amd64.tar.gz -C build $(BINARY_NAME)
 

--- a/author/author.go
+++ b/author/author.go
@@ -11,6 +11,7 @@
 package author
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -18,6 +19,12 @@ import (
 	"github.com/writeas/web-core/log"
 	"github.com/writefreely/writefreely/config"
 )
+
+// PagesFS, when set, is used to enumerate reserved page names instead of
+// reading cfg.Server.PagesParentDir off disk. The main writefreely package
+// sets this at startup to its pages filesystem, which may be backed by
+// assets embedded in the binary rather than files on disk.
+var PagesFS fs.FS
 
 // Regex pattern for valid usernames
 var validUsernameReg = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9-]*$")
@@ -115,11 +122,15 @@ func IsValidUsername(cfg *config.Config, username string) bool {
 	// Username is invalid if page with the same name exists. So traverse
 	// available pages, adding them to reservedUsernames map that'll be checked
 	// later.
-	err := filepath.Walk(filepath.Join(cfg.Server.PagesParentDir, "pages"), func(path string, i os.FileInfo, err error) error {
+	pagesFS := PagesFS
+	if pagesFS == nil {
+		pagesFS = os.DirFS(filepath.Join(cfg.Server.PagesParentDir, "pages"))
+	}
+	err := fs.WalkDir(pagesFS, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		reservedUsernames[i.Name()] = true
+		reservedUsernames[d.Name()] = true
 		return nil
 	})
 	if err != nil {

--- a/routes.go
+++ b/routes.go
@@ -13,7 +13,6 @@ package writefreely
 import (
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strings"
 
 	"github.com/gorilla/csrf"
@@ -27,7 +26,7 @@ import (
 // TODO: this should just be a func, not method
 func (app *App) InitStaticRoutes(r *mux.Router) {
 	// Handle static files
-	fs := http.FileServer(http.Dir(filepath.Join(app.cfg.Server.StaticParentDir, staticDir)))
+	fs := http.FileServer(staticFileSystem(app.cfg.Server.StaticParentDir))
 	fs = cacheControl(fs)
 	app.shttp = http.NewServeMux()
 	app.shttp.Handle("/", fs)

--- a/static_fs_disk.go
+++ b/static_fs_disk.go
@@ -1,0 +1,24 @@
+//go:build !embed
+
+/*
+ * Copyright © 2026 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package writefreely
+
+import (
+	"net/http"
+	"path/filepath"
+)
+
+// staticFileSystem serves static assets straight off disk. This is the
+// default build, so editing files under static/ is picked up without a rebuild.
+func staticFileSystem(parentDir string) http.FileSystem {
+	return http.Dir(filepath.Join(parentDir, staticDir))
+}

--- a/static_fs_embed.go
+++ b/static_fs_embed.go
@@ -1,0 +1,51 @@
+//go:build embed
+// +build embed
+
+/*
+ * Copyright © 2026 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package writefreely
+
+import (
+	"embed"
+	"io/fs"
+	"net/http"
+	"path/filepath"
+)
+
+//go:embed static
+var embeddedStaticFiles embed.FS
+
+// staticFileSystem serves static assets embedded in the binary at build
+// time, falling back to disk-based lookups so file-based overrides -- like
+// static/local/custom.css, which is created after deployment and is never
+// embedded -- still take precedence over the embedded copy.
+func staticFileSystem(parentDir string) http.FileSystem {
+	sub, err := fs.Sub(embeddedStaticFiles, staticDir)
+	if err != nil {
+		panic(err)
+	}
+	return &overlayFileSystem{
+		disk:     http.Dir(filepath.Join(parentDir, staticDir)),
+		embedded: http.FS(sub),
+	}
+}
+
+type overlayFileSystem struct {
+	disk     http.FileSystem
+	embedded http.FileSystem
+}
+
+func (o *overlayFileSystem) Open(name string) (http.File, error) {
+	if f, err := o.disk.Open(name); err == nil {
+		return f, nil
+	}
+	return o.embedded.Open(name)
+}

--- a/templates.go
+++ b/templates.go
@@ -14,14 +14,15 @@ import (
 	"errors"
 	"html/template"
 	"io"
+	"io/fs"
 	"net/http"
-	"os"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"github.com/dustin/go-humanize"
 	"github.com/writeas/web-core/l10n"
 	"github.com/writeas/web-core/log"
+	"github.com/writefreely/writefreely/author"
 	"github.com/writefreely/writefreely/config"
 )
 
@@ -49,77 +50,118 @@ const (
 	pagesDir     = "pages"
 )
 
+// tmplFile identifies a template file within a specific filesystem, since
+// the files that make up a single parsed template can be split across the
+// independently-configurable templates/ and pages/ trees.
+type tmplFile struct {
+	fsys fs.FS
+	name string
+}
+
+// parseTemplateSet parses files into t in order, associating each with t the
+// same way (html/template.Template).ParseFiles does -- it just reads from
+// each file's own fs.FS instead of assuming a single filesystem.
+func parseTemplateSet(t *template.Template, files ...tmplFile) (*template.Template, error) {
+	if len(files) == 0 {
+		return nil, errors.New("template: no files named in call")
+	}
+	for _, tf := range files {
+		b, err := fs.ReadFile(tf.fsys, tf.name)
+		if err != nil {
+			return nil, err
+		}
+		name := path.Base(tf.name)
+		var tmpl *template.Template
+		if name == t.Name() {
+			tmpl = t
+		} else {
+			tmpl = t.New(name)
+		}
+		_, err = tmpl.Parse(string(b))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return t, nil
+}
+
 func showUserPage(w http.ResponseWriter, name string, obj interface{}) {
 	if obj == nil {
 		log.Error("showUserPage: data is nil!")
 		return
 	}
-	if err := userPages[filepath.Join("user", name+".tmpl")].ExecuteTemplate(w, name, obj); err != nil {
+	if err := userPages[path.Join("user", name+".tmpl")].ExecuteTemplate(w, name, obj); err != nil {
 		log.Error("Error parsing %s: %v", name, err)
 	}
 }
 
-func initTemplate(parentDir, name string) {
+func initTemplate(tfs fs.FS, name string) {
 	if debugging {
-		log.Info("  " + filepath.Join(parentDir, templatesDir, name+".tmpl"))
+		log.Info("  " + name + ".tmpl")
 	}
 
-	files := []string{
-		filepath.Join(parentDir, templatesDir, name+".tmpl"),
-		filepath.Join(parentDir, templatesDir, "include", "footer.tmpl"),
-		filepath.Join(parentDir, templatesDir, "base.tmpl"),
-		filepath.Join(parentDir, templatesDir, "user", "include", "silenced.tmpl"),
+	files := []tmplFile{
+		{tfs, name + ".tmpl"},
+		{tfs, path.Join("include", "footer.tmpl")},
+		{tfs, "base.tmpl"},
+		{tfs, path.Join("user", "include", "silenced.tmpl")},
 	}
 	if name == "collection" || name == "collection-tags" || name == "collection-archive" || name == "chorus-collection" || name == "read" {
 		// These pages list out collection posts, so we also parse templatesDir + "include/posts.tmpl"
-		files = append(files, filepath.Join(parentDir, templatesDir, "include", "posts.tmpl"))
+		files = append(files, tmplFile{tfs, path.Join("include", "posts.tmpl")})
 	}
 	if name == "chorus-collection" || name == "chorus-collection-post" {
-		files = append(files, filepath.Join(parentDir, templatesDir, "user", "include", "header.tmpl"))
+		files = append(files, tmplFile{tfs, path.Join("user", "include", "header.tmpl")})
 	}
 	if name == "collection" || name == "collection-tags" || name == "collection-archive" || name == "collection-post" || name == "post" || name == "chorus-collection" || name == "chorus-collection-post" {
-		files = append(files, filepath.Join(parentDir, templatesDir, "include", "post-render.tmpl"))
+		files = append(files, tmplFile{tfs, path.Join("include", "post-render.tmpl")})
 	}
-	templates[name] = template.Must(template.New("").Funcs(funcMap).ParseFiles(files...))
+	templates[name] = template.Must(parseTemplateSet(template.New("").Funcs(funcMap), files...))
 }
 
-func initPage(parentDir, path, key string) {
+func initPage(tfs, pfs fs.FS, pagePath, key string) {
 	if debugging {
-		log.Info("  [%s] %s", key, path)
+		log.Info("  [%s] %s", key, pagePath)
 	}
 
-	files := []string{
-		path,
-		filepath.Join(parentDir, templatesDir, "include", "footer.tmpl"),
-		filepath.Join(parentDir, templatesDir, "base.tmpl"),
-		filepath.Join(parentDir, templatesDir, "user", "include", "silenced.tmpl"),
+	files := []tmplFile{
+		{pfs, pagePath},
+		{tfs, path.Join("include", "footer.tmpl")},
+		{tfs, "base.tmpl"},
+		{tfs, path.Join("user", "include", "silenced.tmpl")},
 	}
 
 	if key == "login.tmpl" || key == "landing.tmpl" || key == "signup.tmpl" {
-		files = append(files, filepath.Join(parentDir, templatesDir, "include", "oauth.tmpl"))
+		files = append(files, tmplFile{tfs, path.Join("include", "oauth.tmpl")})
 	}
 
-	pages[key] = template.Must(template.New("").Funcs(funcMap).ParseFiles(files...))
+	pages[key] = template.Must(parseTemplateSet(template.New("").Funcs(funcMap), files...))
 }
 
-func initUserPage(parentDir, path, key string) {
+func initUserPage(tfs fs.FS, userPagePath, key string) {
 	if debugging {
-		log.Info("  [%s] %s", key, path)
+		log.Info("  [%s] %s", key, userPagePath)
 	}
 
-	userPages[key] = template.Must(template.New(key).Funcs(funcMap).ParseFiles(
-		path,
-		filepath.Join(parentDir, templatesDir, "user", "include", "header.tmpl"),
-		filepath.Join(parentDir, templatesDir, "user", "include", "footer.tmpl"),
-		filepath.Join(parentDir, templatesDir, "user", "include", "silenced.tmpl"),
-		filepath.Join(parentDir, templatesDir, "user", "include", "nav.tmpl"),
+	userPages[key] = template.Must(parseTemplateSet(template.New(key).Funcs(funcMap),
+		tmplFile{tfs, userPagePath},
+		tmplFile{tfs, path.Join("user", "include", "header.tmpl")},
+		tmplFile{tfs, path.Join("user", "include", "footer.tmpl")},
+		tmplFile{tfs, path.Join("user", "include", "silenced.tmpl")},
+		tmplFile{tfs, path.Join("user", "include", "nav.tmpl")},
 	))
 }
 
 // InitTemplates loads all template files from the configured parent dir.
 func InitTemplates(cfg *config.Config) error {
+	tfs := templatesFileSystem(cfg.Server.TemplatesParentDir)
+	pfs := pagesFileSystem(cfg.Server.PagesParentDir)
+	// Let the author package resolve reserved usernames against the same
+	// (possibly embedded) pages filesystem instead of reading disk directly.
+	author.PagesFS = pfs
+
 	log.Info("Loading templates...")
-	tmplFiles, err := os.ReadDir(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir))
+	tmplFiles, err := fs.ReadDir(tfs, ".")
 	if err != nil {
 		return err
 	}
@@ -128,19 +170,19 @@ func InitTemplates(cfg *config.Config) error {
 		if !f.IsDir() && !strings.HasPrefix(f.Name(), ".") {
 			parts := strings.Split(f.Name(), ".")
 			key := parts[0]
-			initTemplate(cfg.Server.TemplatesParentDir, key)
+			initTemplate(tfs, key)
 		}
 	}
 
 	log.Info("Loading pages...")
 	// Initialize all static pages that use the base template
-	err = filepath.Walk(filepath.Join(cfg.Server.PagesParentDir, pagesDir), func(path string, i os.FileInfo, err error) error {
+	err = fs.WalkDir(pfs, ".", func(p string, i fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if !i.IsDir() && !strings.HasPrefix(i.Name(), ".") {
 			key := i.Name()
-			initPage(cfg.Server.PagesParentDir, path, key)
+			initPage(tfs, pfs, p, key)
 		}
 
 		return nil
@@ -151,21 +193,15 @@ func InitTemplates(cfg *config.Config) error {
 
 	log.Info("Loading user pages...")
 	// Initialize all user pages that use base templates
-	err = filepath.Walk(filepath.Join(cfg.Server.TemplatesParentDir, templatesDir, "user"), func(path string, f os.FileInfo, err error) error {
+	err = fs.WalkDir(tfs, "user", func(p string, f fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if !f.IsDir() && !strings.HasPrefix(f.Name(), ".") {
-			corePath := path
-			if cfg.Server.TemplatesParentDir != "" {
-				corePath = corePath[len(cfg.Server.TemplatesParentDir)+1:]
-			}
-			parts := strings.Split(corePath, string(filepath.Separator))
-			key := f.Name()
-			if len(parts) > 2 {
-				key = filepath.Join(parts[1], f.Name())
-			}
-			initUserPage(cfg.Server.TemplatesParentDir, path, key)
+			// However deep the file is under templates/user/, it's keyed
+			// the same way showUserPage looks it up: "user/<basename>".
+			key := path.Join("user", f.Name())
+			initUserPage(tfs, p, key)
 		}
 
 		return nil

--- a/templates_fs_disk.go
+++ b/templates_fs_disk.go
@@ -1,0 +1,42 @@
+//go:build !embed
+
+/*
+ * Copyright © 2026 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package writefreely
+
+import (
+	"io/fs"
+	"os"
+)
+
+// templatesFileSystem serves templates straight off disk. This is the
+// default build, so editing files under templates/ is picked up without a
+// rebuild.
+func templatesFileSystem(parentDir string) fs.FS {
+	return diskContentFS(parentDir, templatesDir)
+}
+
+// pagesFileSystem serves pages straight off disk.
+func pagesFileSystem(parentDir string) fs.FS {
+	return diskContentFS(parentDir, pagesDir)
+}
+
+func diskContentFS(parentDir, sub string) fs.FS {
+	root := parentDir
+	if root == "" {
+		root = "."
+	}
+	subFS, err := fs.Sub(os.DirFS(root), sub)
+	if err != nil {
+		panic(err)
+	}
+	return subFS
+}

--- a/templates_fs_embed.go
+++ b/templates_fs_embed.go
@@ -1,0 +1,64 @@
+//go:build embed
+
+/*
+ * Copyright © 2026 Musing Studio LLC.
+ *
+ * This file is part of WriteFreely.
+ *
+ * WriteFreely is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, included
+ * in the LICENSE file in this source code package.
+ */
+
+package writefreely
+
+import (
+	"embed"
+	"io/fs"
+	"os"
+)
+
+//go:embed templates pages
+var embeddedContentFiles embed.FS
+
+// templatesFileSystem serves templates embedded in the binary at build
+// time, falling back to disk only for paths an admin has explicitly
+// overridden -- e.g. by pointing templates_parent_dir at a custom theme, or
+// dropping a replacement file next to the binary.
+func templatesFileSystem(parentDir string) fs.FS {
+	return overlayContentFS(parentDir, templatesDir)
+}
+
+// pagesFileSystem serves pages embedded in the binary, with the same
+// disk-overrides-embedded behavior as templatesFileSystem.
+func pagesFileSystem(parentDir string) fs.FS {
+	return overlayContentFS(parentDir, pagesDir)
+}
+
+func overlayContentFS(parentDir, sub string) fs.FS {
+	root := parentDir
+	if root == "" {
+		root = "."
+	}
+	disk, err := fs.Sub(os.DirFS(root), sub)
+	if err != nil {
+		panic(err)
+	}
+	embedded, err := fs.Sub(embeddedContentFiles, sub)
+	if err != nil {
+		panic(err)
+	}
+	return &diskEmbedOverlayFS{disk: disk, embedded: embedded}
+}
+
+type diskEmbedOverlayFS struct {
+	disk     fs.FS
+	embedded fs.FS
+}
+
+func (o *diskEmbedOverlayFS) Open(name string) (fs.File, error) {
+	if f, err := o.disk.Open(name); err == nil {
+		return f, nil
+	}
+	return o.embedded.Open(name)
+}


### PR DESCRIPTION
This adds the `embed` build tag to WriteFreely, which tells the compiler to embed the `static`, `template`, and `pages` directories directly into the binary, to be used for `release` builds and to make upgrading simpler.

When compiled this way, certain custom override files like `static/local/custom.css` are still supported.

Closes [T536](https://writefreely.org/tasks/536)

_I'm looking for feedback on this -- upsides, downsides, changes that should be made. Please feel free to discuss here!_

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
