### PR TITLE
Support users recovering username from their email address automatically

### DIFF
--- a/account.go
+++ b/account.go
@@ -1413,6 +1413,169 @@ func emailPasswordReset(app *App, toEmail, token string) error {
 	return mlr.Send(m)
 }
 
+// forgotUsernameAvailable reports whether the username-recovery feature can run on this instance. It requires email to
+// be configured (to send the reminder) and password authentication to be enabled. On an OAuth-only instance the
+// WriteFreely username isn't used to log in, so there's nothing to recover.
+func forgotUsernameAvailable(app *App) bool {
+	return app.cfg.Email.Enabled() && !app.cfg.App.DisablePasswordAuth
+}
+
+func viewForgotUsername(app *App, w http.ResponseWriter, r *http.Request) error {
+	if r.Method == http.MethodPost {
+		return handleForgotUsernameInit(app, w, r)
+	}
+
+	f, _ := getSessionFlashes(app, w, r, nil)
+
+	d := struct {
+		page.StaticPage
+		Flashes      []string
+		EmailEnabled bool
+		CSRFField    template.HTML
+		IsSent       bool
+	}{
+		StaticPage:   pageForReq(app, r),
+		Flashes:      f,
+		EmailEnabled: app.cfg.Email.Enabled(),
+		CSRFField:    csrf.TemplateField(r),
+		IsSent:       r.FormValue("sent") == "1",
+	}
+	err := pages["forgot-username.tmpl"].ExecuteTemplate(w, "base", d)
+	if err != nil {
+		log.Error("Unable to render forgot username page: %v", err)
+	}
+	return err
+}
+
+// forgotUsernameLimiter throttles the expensive full-table email scan behind /forgot-username, since the endpoint is
+// unauthenticated.
+var forgotUsernameLimiter = struct {
+	sync.Mutex
+	lastReq map[string]time.Time
+}{
+	lastReq: map[string]time.Time{},
+}
+
+const forgotUsernameCooldown = 1 * time.Minute
+
+// allowForgotUsernameReq reports whether the given IP may kick off another username lookup, recording the request time
+// when it may.
+func allowForgotUsernameReq(ip string) bool {
+	now := time.Now()
+	forgotUsernameLimiter.Lock()
+	defer forgotUsernameLimiter.Unlock()
+
+	if last, ok := forgotUsernameLimiter.lastReq[ip]; ok && now.Sub(last) < forgotUsernameCooldown {
+		return false
+	}
+	// Clear out expired entries so the map doesn't grow without bound
+	for k, t := range forgotUsernameLimiter.lastReq {
+		if now.Sub(t) >= forgotUsernameCooldown {
+			delete(forgotUsernameLimiter.lastReq, k)
+		}
+	}
+	forgotUsernameLimiter.lastReq[ip] = now
+	return true
+}
+
+func handleForgotUsernameInit(app *App, w http.ResponseWriter, r *http.Request) error {
+	if !forgotUsernameAvailable(app) {
+		// Email isn't configured or password auth is disabled, so there's
+		// nothing to do; send back to the form, where they'll get an explanation.
+		return impart.HTTPError{http.StatusFound, "/forgot-username"}
+	}
+
+	returnLoc := impart.HTTPError{http.StatusFound, "/forgot-username?sent=1"}
+
+	email := spam.CleanEmail(r.FormValue("email"))
+	if email == "" {
+		addSessionFlash(app, w, r, "Please enter a valid email address.", nil)
+		return impart.HTTPError{http.StatusFound, "/forgot-username"}
+	}
+
+	// Always respond the same way, whether or not the address is on file, so this can't be used to enumerate accounts.
+	// The lookup itself scans and decrypts every stored email, so do it in the background.
+	if allowForgotUsernameReq(spam.GetIP(r)) {
+		go sendForgotUsernameEmail(app, email)
+	}
+
+	addSessionFlash(app, w, r, "If your email address is associated with any account on "+app.cfg.App.SiteName+", you'll receive an email with your username shortly.", nil)
+	return returnLoc
+}
+
+// sendForgotUsernameEmail looks up every account associated with the given cleaned email address and emails the list of
+// usernames to it. It does nothing if no accounts match.
+func sendForgotUsernameEmail(app *App, cleanEmail string) {
+	users, err := app.db.GetUsersByEmail(app.keys, cleanEmail)
+	if err != nil {
+		log.Error("Error looking up usernames for email: %s", err)
+		return
+	}
+	if len(users) == 0 {
+		return
+	}
+
+	usernames := make([]string, 0, len(users))
+	toEmail := ""
+	for i := range users {
+		u := &users[i]
+		if u.IsAdmin() {
+			// Never disclose admin accounts
+			continue
+		}
+		usernames = append(usernames, u.Username)
+		if toEmail == "" {
+			toEmail = u.EmailClear(app.keys)
+		}
+	}
+	if len(usernames) == 0 {
+		return
+	}
+
+	err = emailForgotUsername(app, toEmail, usernames)
+	if err != nil {
+		log.Error("Error sending username reminder: %s", err)
+	}
+}
+
+func emailForgotUsername(app *App, toEmail string, usernames []string) error {
+	mlr, err := mailer.New(app.cfg.Email)
+	if err != nil {
+		return err
+	}
+
+	intro := fmt.Sprintf("We received a request for the %s username associated with this email address.", app.cfg.App.SiteName)
+	if len(usernames) > 1 {
+		intro += " It's associated with more than one account:"
+	}
+	footerPara := "Didn't request this? Your account is still safe, and you can safely ignore this email."
+
+	var plainList, htmlList strings.Builder
+	for _, un := range usernames {
+		plainList.WriteString(fmt.Sprintf("\n - %s", un))
+		htmlList.WriteString(fmt.Sprintf("<li>%s</li>", template.HTMLEscapeString(un)))
+	}
+
+	plainMsg := fmt.Sprintf("%s\n%s\n\nLog in here: %s/login\n\n%s", intro, plainList.String(), app.cfg.App.Host, footerPara)
+	m, err := mlr.NewMessage(mailer.FormatAddress(app.cfg.App.SiteName, "noreply-username@"+app.cfg.Email.Domain), "Your "+app.cfg.App.SiteName+" Username", plainMsg, fmt.Sprintf("<%s>", toEmail))
+	if err != nil {
+		return err
+	}
+	m.AddTag("Username Reminder")
+	m.SetHTML(fmt.Sprintf(`<html>
+	<body style="font-family:Lora, 'Palatino Linotype', Palatino, Baskerville, 'Book Antiqua', 'New York', 'DejaVu serif', serif; font-size: 100%%; margin:1em 2em;">
+		<div style="margin:0 auto; max-width: 40em; font-size: 1.2em;">
+        <h1 style="font-size:1.75em"><a style="text-decoration:none;color:#000;" href="%s">%s</a></h1>
+		<p>%s</p>
+		<ul style="font-size:1.2em;margin-bottom:1.5em;">%s</ul>
+		<p style="font-size:1.2em;margin-bottom:1.5em;"><a href="%s/login">Log in to %s</a></p>
+        <p style="font-size: 0.86em;margin:1em auto">%s</p>
+        </div>
+	</body>
+</html>`, app.cfg.App.Host, app.cfg.App.SiteName, template.HTMLEscapeString(intro), htmlList.String(), app.cfg.App.Host, app.cfg.App.SiteName, footerPara))
+	return mlr.Send(m)
+}
+
 func loginViaEmail(app *App, alias, redirectTo string) error {
 	if !app.cfg.Email.Enabled() {
 		return fmt.Errorf("EMAIL ISN'T CONFIGURED on this server")

--- a/database.go
+++ b/database.go
@@ -40,6 +40,7 @@ import (
 	"github.com/writefreely/writefreely/author"
 	"github.com/writefreely/writefreely/config"
 	"github.com/writefreely/writefreely/key"
+	"github.com/writefreely/writefreely/spam"
 )
 
 const (
@@ -63,6 +64,7 @@ type writestore interface {
 	GetUserByID(int64) (*User, error)
 	GetUserForAuth(string) (*User, error)
 	GetUserForAuthByID(int64) (*User, error)
+	GetUsersByEmail(keys *key.Keychain, cleanEmail string) ([]User, error)
 	GetUserNameFromToken(string) (string, error)
 	GetUserDataFromToken(string) (int64, string, error)
 	GetAPIUser(header string) (*User, error)
@@ -430,6 +432,52 @@ func (db *datastore) GetUserForAuth(username string) (*User, error) {
 	}
 
 	return u, nil
+}
+
+// GetUsersByEmail returns every user whose email address matches the given cleaned address (see spam.CleanEmail).
+// Because emails are stored encrypted with a random nonce, they can't be matched in SQL. This scans and decrypts every
+// stored address, so it's an expensive call. Use it sparingly.
+func (db *datastore) GetUsersByEmail(keys *key.Keychain, cleanEmail string) ([]User, error) {
+	if cleanEmail == "" {
+		return nil, nil
+	}
+
+	rows, err := db.Query("SELECT id, username, email, created, status FROM users WHERE email IS NOT NULL")
+	if err != nil {
+		log.Error("Couldn't SELECT users for email lookup: %v", err)
+		return nil, err
+	}
+	defer rows.Close()
+
+	users := []User{}
+	for rows.Next() {
+		u := User{}
+		e := []byte{}
+		err = rows.Scan(&u.ID, &u.Username, &e, &u.Created, &u.Status)
+		if err != nil {
+			log.Error("Couldn't scan user row for email lookup: %v", err)
+			continue
+		}
+		if len(e) == 0 {
+			continue
+		}
+		email, err := data.Decrypt(keys.EmailKey, e)
+		if err != nil {
+			log.Error("Couldn't decrypt email for user %d: %v", u.ID, err)
+			continue
+		}
+
+		if spam.CleanEmail(string(email)) == cleanEmail {
+			u.clearEmail = string(email)
+			users = append(users, u)
+		}
+	}
+	if err = rows.Err(); err != nil {
+		log.Error("Error iterating users for email lookup: %v", err)
+		return nil, err
+	}
+
+	return users, nil
 }
 
 func (db *datastore) GetUserForAuthByID(userID int64) (*User, error) {

--- a/pages/forgot-username.tmpl
+++ b/pages/forgot-username.tmpl
@@ -1,0 +1,50 @@
+{{define "head"}}<title>Forgot username &mdash; {{.SiteName}}</title>
+<style>
+input {
+	margin-bottom: 0.5em;
+	width: 100%;
+	box-sizing: border-box;
+}
+label {
+	display: block;
+}
+</style>
+{{end}}
+{{define "content"}}
+<div class="toosmall content-container clean">
+	<h1>Forgot your username?</h1>
+
+{{ if .DisablePasswordAuth }}
+	<div class="alert info">
+		<p><strong>Password login is disabled on this server</strong>, so usernames aren't used to log in. Please log in with the option shown on the <a href="/login">login page</a>.</p>
+	</div>
+{{ else if not .EmailEnabled }}
+	<div class="alert info">
+		<p><strong>Email is not configured on this server!</strong> Please <a href="/contact">contact your admin</a> to recover your username.</p>
+	</div>
+{{ else }}
+	{{if .Flashes}}<ul class="errors">
+		{{range .Flashes}}<li class="urgent">{{.}}</li>{{end}}
+	</ul>{{end}}
+
+	{{if not .IsSent}}
+		<p>Enter the email address associated with your account, and we'll send you your username (or usernames).</p>
+
+		<form action="/forgot-username" method="post" onsubmit="disableSubmit()">
+			<label>
+				<p>Email address</p>
+				<input type="email" name="email" placeholder="me@example.com" autofocus />
+			</label>
+			{{ .CSRFField }}
+			<input type="submit" id="btn-login" value="Send Username" />
+		</form>
+
+		<script type="text/javascript">
+		var $btn = document.getElementById("btn-login");
+		function disableSubmit() {
+			$btn.disabled = true;
+		}
+		</script>
+	{{end}}
+{{ end }}
+{{end}}

--- a/pages/login.tmpl
+++ b/pages/login.tmpl
@@ -24,6 +24,7 @@ p.forgot {
 {{if not .DisablePasswordAuth}}
 	<form action="/auth/login" method="post" style="text-align: center;margin-top:1em;" onsubmit="disableSubmit()">
 		<input type="text" name="alias" placeholder="Username" value="{{.LoginUsername}}" {{if not .LoginUsername}}autofocus{{end}} /><br />
+        {{if .EmailEnabled}}<p class="forgot"><a href="/forgot-username">Forgot username?</a></p>{{end}}
 		<input type="password" name="pass" placeholder="Password" {{if .LoginUsername}}autofocus{{end}} /><br />
 		{{if .EmailEnabled}}<p class="forgot"><a href="/reset">Forgot password?</a></p>{{end}}
 		{{if .To}}<input type="hidden" name="to" value="{{.To}}" />{{end}}

--- a/pages/reset.tmpl
+++ b/pages/reset.tmpl
@@ -8,6 +8,10 @@ input {
 label {
 	display: block;
 }
+p.forgot {
+	font-size: 0.86em;
+	margin-top: 0.5em;
+}
 </style>
 {{end}}
 {{define "content"}}
@@ -43,6 +47,7 @@ label {
 				<p>Username</p>
 				<input type="text" name="alias" placeholder="Username" autofocus />
 			</label>
+			<p class="forgot"><a href="/forgot-username">Forgot username?</a></p>
 			{{ .CSRFField }}
 			<input type="submit" id="btn-login" value="Reset Password" />
 		</form>

--- a/routes.go
+++ b/routes.go
@@ -186,6 +186,7 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 
 	// Handle special pages first
 	write.Path("/reset").Handler(csrf.Protect(apper.App().keys.CSRFKey, csrf.Path("/"))(handler.Web(viewResetPassword, UserLevelNoneRequired)))
+	write.Path("/forgot-username").Handler(csrf.Protect(apper.App().keys.CSRFKey, csrf.Path("/"))(handler.Web(viewForgotUsername, UserLevelNoneRequired)))
 	write.HandleFunc("/login", handler.Web(viewLogin, UserLevelNoneRequired))
 	write.HandleFunc("/signup", handler.Web(handleViewLanding, UserLevelNoneRequired))
 	write.HandleFunc("/invite/{code:[a-zA-Z0-9]+}", handler.Web(handleViewInvite, UserLevelOptional)).Methods("GET")


### PR DESCRIPTION
When email is configured on an instance, this gives users the option to automatically recover their username(s) via email. They simply need to input their email address, and if any user is associated, they'll receive an email with a list of all usernames associated with that email address, so they can log in / reset their password.

Closes [T939](https://writefreely.org/task/939)

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
