### PR TITLE
Return actual list of followers

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -44,6 +44,8 @@ const (
 	apCustomHandleDefault = "blog"
 
 	apCacheTime = time.Minute
+
+	apFollowersPageSize = 20
 )
 
 var (
@@ -249,24 +251,55 @@ func handleFetchCollectionFollowers(app *App, w http.ResponseWriter, r *http.Req
 		return err
 	}
 
+	total := len(*folls)
 	page := r.FormValue("page")
 	p, err := strconv.Atoi(page)
 	if err != nil || p < 1 {
 		// Return outbox
 		oc := activitystreams.NewOrderedCollection(accountRoot, "followers", len(*folls))
+		// Return the root followers collection
+		oc := activitystreams.NewOrderedCollection(accountRoot, "followers", total)
 		return impart.RenderActivityJSON(w, oc, http.StatusOK)
 	}
 
-	// Return outbox page
-	ocp := activitystreams.NewOrderedCollectionPage(accountRoot, "followers", len(*folls), p)
-	ocp.OrderedItems = []interface{}{}
-	/*
-		for _, f := range *folls {
-			ocp.OrderedItems = append(ocp.OrderedItems, f.ActorID)
-		}
-	*/
+	actorIDs := make([]string, 0, total)
+	for _, f := range *folls {
+		actorIDs = append(actorIDs, f.ActorID)
+	}
+	ocp := apCollectionPage(accountRoot, "followers", actorIDs, p)
+
 	setCacheControl(w, apCacheTime)
 	return impart.RenderActivityJSON(w, ocp, http.StatusOK)
+}
+
+// apCollectionPage builds a single OrderedCollectionPage of actor IDs for an ActivityPub followers/following
+// collection. It slices items into pages of apFollowersPageSize and sets the Next/Prev links so that only pages with
+// content are advertised.
+func apCollectionPage(accountRoot, collType string, actorIDs []string, page int) *activitystreams.OrderedCollectionPage {
+	total := len(actorIDs)
+	ocp := activitystreams.NewOrderedCollectionPage(accountRoot, collType, total, page)
+	ocp.OrderedItems = []interface{}{}
+
+	start := (page - 1) * apFollowersPageSize
+	end := start + apFollowersPageSize
+	if end > total {
+		end = total
+	}
+	if start < end {
+		for _, id := range actorIDs[start:end] {
+			ocp.OrderedItems = append(ocp.OrderedItems, id)
+		}
+	}
+
+	// NewOrderedCollectionPage unconditionally sets Next, so clear it on the
+	// final (or out-of-range) page to avoid presenting an endless collection.
+	if end >= total {
+		ocp.Next = ""
+	}
+	if page > 1 {
+		ocp.Prev = fmt.Sprintf("%s/%s?page=%d", accountRoot, collType, page-1)
+	}
+	return ocp
 }
 
 func handleFetchCollectionFollowing(app *App, w http.ResponseWriter, r *http.Request) error {
@@ -302,12 +335,11 @@ func handleFetchCollectionFollowing(app *App, w http.ResponseWriter, r *http.Req
 	page := r.FormValue("page")
 	p, err := strconv.Atoi(page)
 	if err != nil || p < 1 {
-		// Return outbox
+		// Return the root following collection. Blogs don't follow anyone, so this is always empty.
 		oc := activitystreams.NewOrderedCollection(accountRoot, "following", 0)
 		return impart.RenderActivityJSON(w, oc, http.StatusOK)
 	}
 
-	// Return outbox page
 	ocp := activitystreams.NewOrderedCollectionPage(accountRoot, "following", 0, p)
 	ocp.OrderedItems = []interface{}{}
 	setCacheControl(w, apCacheTime)

--- a/activitypub.go
+++ b/activitypub.go
@@ -771,9 +771,9 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 
 func makeActivityPost(hostName string, p *activitystreams.Person, url string, m interface{}) error {
 	if url == "" {
-        log.Error("Target POST URL is empty! Person: %+v, Activity: %+v", p, m)
-        return fmt.Errorf("target POST URL is empty")
-    }
+		log.Error("Target POST URL is empty! Person: %+v, Activity: %+v", p, m)
+		return fmt.Errorf("target POST URL is empty")
+	}
 
 	log.Info("POST %s", url)
 	b, err := json.Marshal(m)

--- a/activitypub.go
+++ b/activitypub.go
@@ -255,8 +255,6 @@ func handleFetchCollectionFollowers(app *App, w http.ResponseWriter, r *http.Req
 	page := r.FormValue("page")
 	p, err := strconv.Atoi(page)
 	if err != nil || p < 1 {
-		// Return outbox
-		oc := activitystreams.NewOrderedCollection(accountRoot, "followers", len(*folls))
 		// Return the root followers collection
 		oc := activitystreams.NewOrderedCollection(accountRoot, "followers", total)
 		setCacheControl(w, apCacheTime)

--- a/activitypub.go
+++ b/activitypub.go
@@ -259,6 +259,7 @@ func handleFetchCollectionFollowers(app *App, w http.ResponseWriter, r *http.Req
 		oc := activitystreams.NewOrderedCollection(accountRoot, "followers", len(*folls))
 		// Return the root followers collection
 		oc := activitystreams.NewOrderedCollection(accountRoot, "followers", total)
+		setCacheControl(w, apCacheTime)
 		return impart.RenderActivityJSON(w, oc, http.StatusOK)
 	}
 
@@ -337,6 +338,7 @@ func handleFetchCollectionFollowing(app *App, w http.ResponseWriter, r *http.Req
 	if err != nil || p < 1 {
 		// Return the root following collection. Blogs don't follow anyone, so this is always empty.
 		oc := activitystreams.NewOrderedCollection(accountRoot, "following", 0)
+		setCacheControl(w, apCacheTime)
 		return impart.RenderActivityJSON(w, oc, http.StatusOK)
 	}
 

--- a/activitypub_test.go
+++ b/activitypub_test.go
@@ -1,6 +1,7 @@
 package writefreely
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/writeas/web-core/activitystreams"
@@ -28,4 +29,80 @@ func TestUnmarshalActor(t *testing.T) {
 			t.Errorf("%s failed with error %s", tc.Name, err)
 		}
 	}
+}
+
+func TestAPCollectionPage(t *testing.T) {
+	const root = "https://example.com/api/collections/blog"
+
+	makeActors := func(n int) []string {
+		actors := make([]string, n)
+		for i := 0; i < n; i++ {
+			actors[i] = fmt.Sprintf("https://remote.example/users/%d", i)
+		}
+		return actors
+	}
+
+	t.Run("full first page with more to come", func(t *testing.T) {
+		actors := makeActors(apFollowersPageSize + 5)
+		ocp := apCollectionPage(root, "followers", actors, 1)
+
+		if got := len(ocp.OrderedItems); got != apFollowersPageSize {
+			t.Errorf("expected %d items on page 1, got %d", apFollowersPageSize, got)
+		}
+		if ocp.OrderedItems[0] != actors[0] {
+			t.Errorf("expected first item %q, got %q", actors[0], ocp.OrderedItems[0])
+		}
+		wantNext := fmt.Sprintf("%s/followers?page=2", root)
+		if ocp.Next != wantNext {
+			t.Errorf("expected Next %q, got %q", wantNext, ocp.Next)
+		}
+		if ocp.Prev != "" {
+			t.Errorf("expected no Prev on page 1, got %q", ocp.Prev)
+		}
+		if ocp.PartOf != root+"/followers" {
+			t.Errorf("expected PartOf %q, got %q", root+"/followers", ocp.PartOf)
+		}
+		if ocp.TotalItems != len(actors) {
+			t.Errorf("expected TotalItems %d, got %d", len(actors), ocp.TotalItems)
+		}
+	})
+
+	t.Run("last page clears Next and sets Prev", func(t *testing.T) {
+		actors := makeActors(apFollowersPageSize + 5)
+		ocp := apCollectionPage(root, "followers", actors, 2)
+
+		if got := len(ocp.OrderedItems); got != 5 {
+			t.Errorf("expected 5 items on last page, got %d", got)
+		}
+		if ocp.Next != "" {
+			t.Errorf("expected no Next on last page, got %q", ocp.Next)
+		}
+		wantPrev := fmt.Sprintf("%s/followers?page=1", root)
+		if ocp.Prev != wantPrev {
+			t.Errorf("expected Prev %q, got %q", wantPrev, ocp.Prev)
+		}
+	})
+
+	t.Run("out-of-range page is empty with no Next", func(t *testing.T) {
+		actors := makeActors(3)
+		ocp := apCollectionPage(root, "followers", actors, 5)
+
+		if len(ocp.OrderedItems) != 0 {
+			t.Errorf("expected no items on out-of-range page, got %d", len(ocp.OrderedItems))
+		}
+		if ocp.Next != "" {
+			t.Errorf("expected no Next on out-of-range page, got %q", ocp.Next)
+		}
+	})
+
+	t.Run("empty collection", func(t *testing.T) {
+		ocp := apCollectionPage(root, "followers", []string{}, 1)
+
+		if len(ocp.OrderedItems) != 0 {
+			t.Errorf("expected no items, got %d", len(ocp.OrderedItems))
+		}
+		if ocp.Next != "" {
+			t.Errorf("expected no Next on empty collection, got %q", ocp.Next)
+		}
+	})
 }


### PR DESCRIPTION
This exposes an actual OrderedCollection of followers via ActivityPub.

Building on #1733, this completes the #1698 implementation. Kept as a draft only for the discussion that needs to happen (see below).

### Feedback

This presents new privacy concerns, as we'd be publicly exposing specific blog followers where they weren't before. This is generally fine in the social media world, but we've never made this data publicly available on WriteFreely, and some authors might be relying on that.

My gut instinct is that we should make this opt-in for existing users (and maybe new users, too), by default keeping today's behavior where we only expose the number of followers, but not the list. Of course, users may discover other followers of a WF blog via platforms like Mastodon that show fellow followers on a user's instance. But from what we can control, the behavior stays the same.

What does everyone think?

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
