### PR TITLE
Enforce signup checks consistently across all registration paths

### DIFF
--- a/account.go
+++ b/account.go
@@ -134,6 +134,15 @@ func signup(app *App, w http.ResponseWriter, r *http.Request) (*AuthUser, error)
 func signupWithRegistration(app *App, signup userRegistration, w http.ResponseWriter, r *http.Request) (*AuthUser, error) {
 	reqJSON := IsJSON(r)
 
+	// Signup checks are enforced here to keep them from being bypassed on different endpoints.
+	if app.cfg.App.DisablePasswordAuth {
+		return nil, ErrDisabledPasswordAuth
+	}
+	// Closed registration requires a valid, active invite code.
+	if err := app.canRegister(signup.InviteCode); err != nil {
+		return nil, err
+	}
+
 	// Validate required params (alias)
 	if signup.Alias == "" {
 		return nil, impart.HTTPError{http.StatusBadRequest, "A username is required."}

--- a/oauth_signup.go
+++ b/oauth_signup.go
@@ -84,6 +84,9 @@ func (p oauthSignupPageParams) HashTokenParams(key string) string {
 	hasher.Write([]byte(p.TokenRemoteUser))
 	hasher.Write([]byte(p.ClientID))
 	hasher.Write([]byte(p.Provider))
+	// Include the invite code so it can't be swapped out between the callback (where it was validated) and this
+	// completion step.
+	hasher.Write([]byte(p.InviteCode))
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
@@ -102,6 +105,14 @@ func (h oauthHandler) viewOauthSignup(app *App, w http.ResponseWriter, r *http.R
 		return impart.HTTPError{Status: http.StatusBadRequest, Message: "Request has been tampered with."}
 	}
 	tp.TokenHash = tp.HashTokenParams(h.Config.Server.HashSeed)
+	// Re-check registration eligibility at the completion step rather than
+	// trusting that the callback already did. The signed hash proves the OAuth
+	// identity params (including the invite code) weren't tampered with, but
+	// the account is only actually created here -- so this is where closed
+	// registration and invite validity must be enforced.
+	if err := app.canRegister(tp.InviteCode); err != nil {
+		return h.showOauthSignupPage(app, w, r, tp, err)
+	}
 	if err := h.validateOauthSignup(r); err != nil {
 		return h.showOauthSignupPage(app, w, r, tp, err)
 	}

--- a/routes.go
+++ b/routes.go
@@ -85,9 +85,7 @@ func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	// Set up dynamic page handlers
 	// Handle auth
 	auth := write.PathPrefix("/api/auth/").Subrouter()
-	if apper.App().cfg.App.OpenRegistration {
-		auth.HandleFunc("/signup", handler.All(apiSignup)).Methods("POST")
-	}
+	auth.HandleFunc("/signup", handler.All(apiSignup)).Methods("POST")
 	auth.HandleFunc("/login", handler.All(login)).Methods("POST")
 	auth.HandleFunc("/read", handler.WebErrors(handleWebCollectionUnlock, UserLevelNone)).Methods("POST")
 	auth.HandleFunc("/me", handler.All(handleAPILogout)).Methods("DELETE")

--- a/signup_test.go
+++ b/signup_test.go
@@ -231,6 +231,47 @@ func TestAPISignupOpenRegistrationStillWorks(t *testing.T) {
 	assert.True(t, userExists(t, app, "apisignup-open"))
 }
 
+// TestSignupDisabledPasswordAuth guards against creating a password-based
+// account when password auth is disabled.
+func TestSignupDisabledPasswordAuth(t *testing.T) {
+	newReq := func(path, alias string) (*http.Request, *httptest.ResponseRecorder) {
+		form := url.Values{}
+		form.Set("alias", alias)
+		form.Set("pass", "sup3rSecret!")
+		req := httptest.NewRequest("POST", path, strings.NewReader(form.Encode()))
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		return req, httptest.NewRecorder()
+	}
+
+	t.Run("api", func(t *testing.T) {
+		app := newSignupTestApp(t)
+		app.cfg.App.OpenRegistration = true
+		app.cfg.App.DisablePasswordAuth = true
+
+		req, w := newReq("/api/auth/signup", "pwauth-api")
+		if err := apiSignup(app, w, req); err != ErrDisabledPasswordAuth {
+			t.Fatalf("expected ErrDisabledPasswordAuth, got: %v", err)
+		}
+		assert.False(t, userExists(t, app, "pwauth-api"))
+	})
+
+	t.Run("web", func(t *testing.T) {
+		app := newSignupTestApp(t)
+		app.cfg.App.OpenRegistration = true
+		app.cfg.App.DisablePasswordAuth = true
+
+		req, w := newReq("/auth/signup", "pwauth-web")
+		// handleWebSignup converts the rejection into a flash + 302 redirect
+		// rather than returning the error verbatim, so the real signal is that
+		// no account was created.
+		err := handleWebSignup(app, w, req)
+		if httpErr, ok := err.(impart.HTTPError); !ok || httpErr.Status != http.StatusFound {
+			t.Fatalf("expected 302 redirect, got: %v", err)
+		}
+		assert.False(t, userExists(t, app, "pwauth-web"))
+	})
+}
+
 // TestInitRoutesAlwaysRegistersAPISignup guards against the routing-time
 // bypass in Finding A: /api/auth/signup used to only be registered when
 // OpenRegistration was true *at boot*, so toggling the setting off at

--- a/unregisteredusers.go
+++ b/unregisteredusers.go
@@ -19,6 +19,25 @@ import (
 	"github.com/writeas/web-core/log"
 )
 
+// canRegister reports whether a new account may be created given the instance's registration setting and the given
+// invite code. When registration is open, anyone may sign up. When it's closed, a valid, still-active invite code is
+// required -- otherwise any non-empty value (or none at all) would be enough to create an account. This is the single
+// gate every signup path (web, API, and OAuth) must pass through so the checks can't be side-stepped by hitting a
+// different endpoint.
+func (app *App) canRegister(inviteCode string) error {
+	if app.cfg.App.OpenRegistration {
+		return nil
+	}
+	i, err := app.db.GetUserInvite(inviteCode)
+	if err != nil {
+		return impart.HTTPError{http.StatusForbidden, "Registration is closed"}
+	}
+	if !i.Active(app.db) {
+		return impart.HTTPError{http.StatusNotFound, "Invite link has expired."}
+	}
+	return nil
+}
+
 func handleWebSignup(app *App, w http.ResponseWriter, r *http.Request) error {
 	reqJSON := IsJSON(r)
 
@@ -44,18 +63,8 @@ func handleWebSignup(app *App, w http.ResponseWriter, r *http.Request) error {
 			return ErrBadFormData
 		}
 	}
-	if !app.cfg.App.OpenRegistration {
-		// Registrations are closed, so an invite is required. Verify the given
-		// code actually exists and is still usable -- otherwise any non-empty
-		// value would be enough to create an account. Mirrors the check the
-		// OAuth signup flow already performs in viewOauthCallback().
-		i, err := app.db.GetUserInvite(ur.InviteCode)
-		if err != nil {
-			return impart.HTTPError{http.StatusForbidden, "Registration is closed"}
-		}
-		if !i.Active(app.db) {
-			return impart.HTTPError{http.StatusNotFound, "Invite link has expired."}
-		}
+	if err := app.canRegister(ur.InviteCode); err != nil {
+		return err
 	}
 	ur.Web = true
 	ur.Normalize = true


### PR DESCRIPTION
Previously, registration eligibility (closed registration, invite validity, and password-auth availability) was checked inconsistently depending on the endpoint, including /api/auth/signup, /oauth/signup, and instances with password auth disabled.

Funnels all paths (web, API, OAuth) through a single canRegister() gate so the checks can't be bypassed by picking a different endpoint, and includes the invite code in the OAuth signature. Extends the invite validation from #1724 to the API and OAuth paths it didn't cover. Also adds regression tests covering each path.

---

- [x] I have signed the [CLA](https://todo.musing.studio/L1)
