### PR TITLE
fix: prevent nil pointer dereference in initActivityPub

### DIFF
--- a/activitypub.go
+++ b/activitypub.go
@@ -55,7 +55,19 @@ var (
 var instanceColl *Collection
 
 func initActivityPub(app *App) {
-	ur, _ := url.Parse(app.cfg.App.Host)
+	if app == nil || app.cfg == nil {
+		log.Error("Unable to initialize ActivityPub: app or cfg is nil")
+		return
+	}
+	if app.cfg.App.Host == "" {
+		log.Error("Unable to initialize ActivityPub: App.Host is empty")
+		return
+	}
+	ur, err := url.Parse(app.cfg.App.Host)
+	if err != nil || ur == nil {
+		log.Error("Unable to initialize ActivityPub: invalid App.Host URL: %v", err)
+		return
+	}
 	instanceColl = &Collection{
 		ID:       0,
 		Alias:    ur.Host,


### PR DESCRIPTION
## Summary

Fixes #1753

Adds nil checks in `initActivityPub` to prevent panic when `app.cfg.App.Host` is empty or contains an invalid URL.

## Changes

- Check if `app` or `app.cfg` is nil before accessing fields
- Check if `app.cfg.App.Host` is empty
- Check if `url.Parse()` returns a nil URL or error
- Log descriptive error messages instead of panicking

## Testing

- [x] Verified fix prevents panic with empty App.Host
- [x] Verified fix prevents panic with invalid App.Host URL
- [x] Verified server starts successfully after fix
- [x] Tested with SQLite backend
- [x] Tested on macOS 26.5.1 (Tahoe), MacBook Pro, Go 1.27.0

## Before

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/writefreely/writefreely.initActivityPub(0xc00011c840)
    activitypub.go:51
```

## After

```
ERROR: Unable to initialize ActivityPub: invalid App.Host URL: parse "://": missing protocol scheme
```

The server continues to start and operate normally.
