### PR TITLE
security: limit HTTP request body size to prevent memory-exhaustion DoS

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -23,6 +23,22 @@ import (
 	"github.com/writefreely/go-nodeinfo"
 )
 
+// maxRequestBodySize is the maximum allowed HTTP request body size. It guards
+// against memory-exhaustion denial of service from unbounded request bodies
+// read by handlers (settings, posts, imports, etc.) via io.ReadAll on r.Body.
+const maxRequestBodySize int64 = 32 << 20
+
+// bodyLimitMiddleware wraps each request body with http.MaxBytesReader so a
+// single oversized request cannot exhaust server memory.
+func bodyLimitMiddleware(maxBytes int64) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			r.Body = http.MaxBytesReader(w, r.Body, maxBytes)
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // InitStaticRoutes adds routes for serving static files.
 // TODO: this should just be a func, not method
 func (app *App) InitStaticRoutes(r *mux.Router) {
@@ -38,6 +54,10 @@ func (app *App) InitStaticRoutes(r *mux.Router) {
 func InitRoutes(apper Apper, r *mux.Router) *mux.Router {
 	// Create handler
 	handler := NewWFHandler(apper)
+
+	// Limit request body size to mitigate memory-exhaustion DoS from unbounded
+	// request bodies read by handlers (settings, posts, imports, etc.).
+	r.Use(bodyLimitMiddleware(maxRequestBodySize))
 
 	// Set up routes
 	hostSubroute := apper.App().cfg.App.Host[strings.Index(apper.App().cfg.App.Host, "://")+3:]


### PR DESCRIPTION
## Summary
Handlers read the request body (settings, posts, imports, collections) via `io.ReadAll` on `r.Body` without an explicit size limit. An attacker can send an unbounded request body and exhaust server memory (denial of service).

`codesentry` (static analysis) flagged 30 such handlers across the dynamic routes.

## Fix
Register a gorilla/mux body-limit middleware on the root router in `InitRoutes` that wraps each request body with `http.MaxBytesReader` (default `32M`). Because the middleware is applied to the root router, it covers all routes including subrouters (`write`, `apiMe`, `apiColls`, `posts`, etc.).

## Notes
- Default is `32M`; happy to make it configurable via `app.config` if you'd prefer it tunable.
- Defense-in-depth hardening; behavior is unchanged for bodies under the limit.

Verified the change is limited to route setup (no handler logic touched).