### PR TITLE
Add configurable datetime slugs with timezone support

### DIFF
--- a/account_import.go
+++ b/account_import.go
@@ -154,7 +154,7 @@ func handleImport(app *App, u *User, w http.ResponseWriter, r *http.Request) err
 			Font:    "norm",
 			Created: &created,
 		}
-		rp, err := app.db.CreatePost(u.ID, coll.ID, &submittedPost)
+		rp, err := app.db.CreatePost(app.cfg, u.ID, coll.ID, &submittedPost)
 		if err != nil {
 			fileErrs = append(fileErrs, fmt.Errorf("failed to create post from %s", formFile.Filename))
 			log.Error("import textfile: create db post: %v", err)

--- a/activitypub.go
+++ b/activitypub.go
@@ -260,6 +260,7 @@ func handleFetchCollectionFollowers(app *App, w http.ResponseWriter, r *http.Req
 	// Return outbox page
 	ocp := activitystreams.NewOrderedCollectionPage(accountRoot, "followers", len(*folls), p)
 	ocp.OrderedItems = []interface{}{}
+	ocp.Next = ""
 	/*
 		for _, f := range *folls {
 			ocp.OrderedItems = append(ocp.OrderedItems, f.ActorID)
@@ -310,6 +311,7 @@ func handleFetchCollectionFollowing(app *App, w http.ResponseWriter, r *http.Req
 	// Return outbox page
 	ocp := activitystreams.NewOrderedCollectionPage(accountRoot, "following", 0, p)
 	ocp.OrderedItems = []interface{}{}
+	ocp.Next = ""
 	setCacheControl(w, apCacheTime)
 	return impart.RenderActivityJSON(w, ocp, http.StatusOK)
 }
@@ -739,9 +741,9 @@ func handleFetchCollectionInbox(app *App, w http.ResponseWriter, r *http.Request
 
 func makeActivityPost(hostName string, p *activitystreams.Person, url string, m interface{}) error {
 	if url == "" {
-        log.Error("Target POST URL is empty! Person: %+v, Activity: %+v", p, m)
-        return fmt.Errorf("target POST URL is empty")
-    }
+		log.Error("Target POST URL is empty! Person: %+v, Activity: %+v", p, m)
+		return fmt.Errorf("target POST URL is empty")
+	}
 
 	log.Info("POST %s", url)
 	b, err := json.Marshal(m)

--- a/bluenote_database_test.go
+++ b/bluenote_database_test.go
@@ -1,0 +1,147 @@
+package writefreely
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/writefreely/writefreely/config"
+)
+
+// The existing helper uses a disposable SQLite database and skips without
+// -tags sqlite. No production database or remote federation server is used.
+func TestBlueNoteEmptyActivityPages(t *testing.T) {
+	app, router := newTemplateTestApp(t, func(cfg *config.Config) { cfg.App.SingleUser = false })
+	_, coll, _ := createTemplateTestUser(t, app, "blue0a6m5c")
+	for _, followerCount := range []int{0, 1} {
+		if followerCount > 0 {
+			res, err := app.db.Exec("INSERT INTO remoteusers (actor_id, inbox, shared_inbox) VALUES (?, ?, ?)",
+				"https://remote.example/users/test", "https://remote.example/inbox", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			id, err := res.LastInsertId()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := app.db.Exec("INSERT INTO remotefollows (collection_id, remote_user_id) VALUES (?, ?)", coll.ID, id); err != nil {
+				t.Fatal(err)
+			}
+		}
+		for _, kind := range []string{"followers", "following"} {
+			for _, page := range []int{1, 2} {
+				t.Run(fmt.Sprintf("%s/followers=%d/page=%d", kind, followerCount, page), func(t *testing.T) {
+					path := fmt.Sprintf("/api/collections/%s/%s?page=%d", coll.Alias, kind, page)
+					req := httptest.NewRequest(http.MethodGet, path, nil)
+					req.Header.Set("Accept", "application/activity+json")
+					rec := httptest.NewRecorder()
+					router.ServeHTTP(rec, req)
+					if rec.Code != http.StatusOK {
+						t.Fatalf("status %d: %s", rec.Code, rec.Body.String())
+					}
+					var body map[string]json.RawMessage
+					if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+						t.Fatal(err)
+					}
+					if string(body["type"]) != `"OrderedCollectionPage"` {
+						t.Fatalf("unexpected page: %s", rec.Body.String())
+					}
+					// web-core marks orderedItems omitempty, so an empty slice
+					// is omitted from the current wire format.
+					var items []json.RawMessage
+					if raw, exists := body["orderedItems"]; exists {
+						if err := json.Unmarshal(raw, &items); err != nil {
+							t.Fatal(err)
+						}
+					}
+					if len(items) != 0 {
+						t.Errorf("expected empty page, got %s", body["orderedItems"])
+					}
+					wantTotal := "0"
+					if kind == "followers" {
+						wantTotal = fmt.Sprint(followerCount)
+					}
+					if string(body["totalItems"]) != wantTotal {
+						t.Errorf("totalItems = %s, want %s", body["totalItems"], wantTotal)
+					}
+					if next, exists := body["next"]; exists {
+						t.Errorf("next must be omitted, got %s", next)
+					}
+				})
+			}
+		}
+	}
+}
+
+func TestBlueNoteClaimDatetimeSlug(t *testing.T) {
+	app, _ := newTemplateTestApp(t, func(cfg *config.Config) { cfg.App.SingleUser = false })
+	for _, alias := range []string{"blue0a6m5c", "otherblog"} {
+		user, coll, direct := createTemplateTestUser(t, app, alias)
+		// Current scope: direct creation still uses the title-based slug.
+		if direct.Slug.String != "hello-world" {
+			t.Fatalf("direct post slug = %q", direct.Slug.String)
+		}
+		for _, viaClaim := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/claim=%t", alias, viaClaim), func(t *testing.T) {
+				title, content, created := "Draft Title", "Draft body", "2001-02-03T04:05:06Z"
+				draft, err := app.db.CreatePost(user.ID, 0, &SubmittedPost{Title: &title, Content: &content, Created: &created})
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					if _, err := app.db.Exec("DELETE FROM posts WHERE id = ?", draft.ID); err != nil {
+						t.Error(err)
+					}
+				})
+				requests := []ClaimPostRequest{{AnonymousAuthPost: &AnonymousAuthPost{ID: draft.ID}}}
+				target := alias
+				if viaClaim {
+					target = ""
+					requests[0].CollectionAlias = alias
+				}
+				before := time.Now().Truncate(time.Second)
+				results, err := app.db.ClaimPosts(app.cfg, user.ID, target, &requests)
+				after := time.Now()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if results == nil || len(*results) != 1 {
+					t.Fatalf("unexpected claim results: %#v", results)
+				}
+				result := (*results)[0]
+				if result.Code != http.StatusOK || result.Post == nil {
+					t.Fatalf("claim failed: %+v", result)
+				}
+				slug := result.Post.Slug.String
+				if alias == "blue0a6m5c" {
+					if !regexp.MustCompile(`^\d{14}$`).MatchString(slug) {
+						t.Fatalf("expected datetime slug, got %q", slug)
+					}
+					// The implementation uses processing time in time.Local, not
+					// the saved publication date. Accept a second boundary crossing.
+					stamp, err := time.ParseInLocation("20060102150405", slug, time.Local)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if stamp.Before(before) || stamp.After(after) {
+						t.Errorf("slug time %s outside [%s, %s]", stamp, before, after)
+					}
+				} else if slug != "draft-title" {
+					t.Errorf("other blog slug = %q, want draft-title", slug)
+				}
+				var savedSlug string
+				var savedCollection int64
+				if err := app.db.QueryRow("SELECT slug, collection_id FROM posts WHERE id = ?", draft.ID).Scan(&savedSlug, &savedCollection); err != nil {
+					t.Fatal(err)
+				}
+				if savedSlug != slug || savedCollection != coll.ID {
+					t.Errorf("saved slug/collection = %q/%d, want %q/%d", savedSlug, savedCollection, slug, coll.ID)
+				}
+			})
+		}
+	}
+}

--- a/bluenote_database_test.go
+++ b/bluenote_database_test.go
@@ -5,9 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"regexp"
+
 	"testing"
-	"time"
 
 	"github.com/writefreely/writefreely/config"
 )
@@ -73,75 +72,6 @@ func TestBlueNoteEmptyActivityPages(t *testing.T) {
 					}
 				})
 			}
-		}
-	}
-}
-
-func TestBlueNoteClaimDatetimeSlug(t *testing.T) {
-	app, _ := newTemplateTestApp(t, func(cfg *config.Config) { cfg.App.SingleUser = false })
-	for _, alias := range []string{"blue0a6m5c", "otherblog"} {
-		user, coll, direct := createTemplateTestUser(t, app, alias)
-		// Current scope: direct creation still uses the title-based slug.
-		if direct.Slug.String != "hello-world" {
-			t.Fatalf("direct post slug = %q", direct.Slug.String)
-		}
-		for _, viaClaim := range []bool{false, true} {
-			t.Run(fmt.Sprintf("%s/claim=%t", alias, viaClaim), func(t *testing.T) {
-				title, content, created := "Draft Title", "Draft body", "2001-02-03T04:05:06Z"
-				draft, err := app.db.CreatePost(user.ID, 0, &SubmittedPost{Title: &title, Content: &content, Created: &created})
-				if err != nil {
-					t.Fatal(err)
-				}
-				t.Cleanup(func() {
-					if _, err := app.db.Exec("DELETE FROM posts WHERE id = ?", draft.ID); err != nil {
-						t.Error(err)
-					}
-				})
-				requests := []ClaimPostRequest{{AnonymousAuthPost: &AnonymousAuthPost{ID: draft.ID}}}
-				target := alias
-				if viaClaim {
-					target = ""
-					requests[0].CollectionAlias = alias
-				}
-				before := time.Now().Truncate(time.Second)
-				results, err := app.db.ClaimPosts(app.cfg, user.ID, target, &requests)
-				after := time.Now()
-				if err != nil {
-					t.Fatal(err)
-				}
-				if results == nil || len(*results) != 1 {
-					t.Fatalf("unexpected claim results: %#v", results)
-				}
-				result := (*results)[0]
-				if result.Code != http.StatusOK || result.Post == nil {
-					t.Fatalf("claim failed: %+v", result)
-				}
-				slug := result.Post.Slug.String
-				if alias == "blue0a6m5c" {
-					if !regexp.MustCompile(`^\d{14}$`).MatchString(slug) {
-						t.Fatalf("expected datetime slug, got %q", slug)
-					}
-					// The implementation uses processing time in time.Local, not
-					// the saved publication date. Accept a second boundary crossing.
-					stamp, err := time.ParseInLocation("20060102150405", slug, time.Local)
-					if err != nil {
-						t.Fatal(err)
-					}
-					if stamp.Before(before) || stamp.After(after) {
-						t.Errorf("slug time %s outside [%s, %s]", stamp, before, after)
-					}
-				} else if slug != "draft-title" {
-					t.Errorf("other blog slug = %q, want draft-title", slug)
-				}
-				var savedSlug string
-				var savedCollection int64
-				if err := app.db.QueryRow("SELECT slug, collection_id FROM posts WHERE id = ?", draft.ID).Scan(&savedSlug, &savedCollection); err != nil {
-					t.Fatal(err)
-				}
-				if savedSlug != slug || savedCollection != coll.ID {
-					t.Errorf("saved slug/collection = %q/%d, want %q/%d", savedSlug, savedCollection, slug, coll.ID)
-				}
-			})
 		}
 	}
 }

--- a/bluenote_posts_test.go
+++ b/bluenote_posts_test.go
@@ -1,0 +1,93 @@
+package writefreely
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writefreely/writefreely/config"
+)
+
+func TestBlueNoteISO8601UTC(t *testing.T) {
+	for _, tc := range []struct {
+		name, input, want string
+	}{
+		{"UTC", "2026-09-05T12:34:56Z", "2026-09-05T12:34:56Z"},
+		{"positive offset crosses year", "2026-01-01T00:30:45+09:00", "2025-12-31T15:30:45Z"},
+		{"negative offset crosses day", "2026-09-05T23:30:45-07:00", "2026-09-06T06:30:45Z"},
+		{"fractional seconds", "2026-09-05T12:34:56.123456+05:30", "2026-09-05T07:04:56Z"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			created, err := time.Parse(time.RFC3339Nano, tc.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			post := &Post{Created: created}
+			raw := &RawPost{Created: created, Updated: created}
+			for name, serialize := range map[string]func() string{
+				"Post.Created8601":    post.Created8601,
+				"RawPost.Created8601": raw.Created8601,
+				"RawPost.Updated8601": raw.Updated8601,
+			} {
+				t.Run(name, func(t *testing.T) {
+					if got := serialize(); got != tc.want {
+						t.Fatalf("got %q, want %q", got, tc.want)
+					}
+				})
+			}
+			if post.Created != created || raw.Created != created || raw.Updated != created {
+				t.Fatal("serialization changed the stored timestamp")
+			}
+		})
+	}
+	if got := (&RawPost{}).Updated8601(); got != "" {
+		t.Fatalf("unset Updated8601 = %q, want empty", got)
+	}
+}
+
+func TestBlueNoteActivityArticleSummary(t *testing.T) {
+	cfg := config.New()
+	cfg.App.Host = "https://example.com"
+	cfg.App.NotesOnly = false
+	app := &App{cfg: cfg}
+	for _, tc := range []struct {
+		name, content, want string
+	}{
+		{"markdown", "**Hello** & [world](https://example.org).\n\nSecond paragraph.", "Hello & world. [...]"},
+		{"HTML and entities", "<strong>日本語</strong> &amp; &#39;quotes&#39;.\n\nSecond paragraph.", "日本語 & 'quotes'. [...]"},
+		{"explicit excerpt", "**Before**<!--more-->Hidden\n\nSecond paragraph.", "Before [...]"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			post := &PublicPost{
+				Post:       &Post{ID: "testpost01", Content: tc.content, Created: time.Date(2026, 9, 5, 0, 0, 0, 0, time.UTC)},
+				Collection: &CollectionObj{Collection: Collection{Alias: "blue0a6m5c", hostName: cfg.App.Host}},
+			}
+			obj := post.ActivityObject(app)
+			data, err := json.Marshal(obj)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var wire struct {
+				Type    string  `json:"type"`
+				Summary *string `json:"summary"`
+				Content string  `json:"content"`
+				Preview struct {
+					Content string `json:"content"`
+				} `json:"preview"`
+			}
+			if err := json.Unmarshal(data, &wire); err != nil {
+				t.Fatal(err)
+			}
+			if wire.Type != "Article" || wire.Summary == nil {
+				t.Fatalf("expected Article with summary: %s", data)
+			}
+			if *wire.Summary != tc.want {
+				t.Errorf("summary = %q, want %q", *wire.Summary, tc.want)
+			}
+			if !strings.Contains(wire.Preview.Content, "<strong>") || !strings.Contains(wire.Content, "<strong>") {
+				t.Errorf("body and preview must retain HTML: %s", data)
+			}
+		})
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-ini/ini"
 	"github.com/writeas/web-core/log"
@@ -141,6 +142,10 @@ type (
 		Forest        bool `ini:"forest"` // The admin cares about the forest, not the trees. Hide unnecessary technical info.
 		DisableDrafts bool `ini:"disable_drafts"`
 
+		DatetimeSlugs        bool   `ini:"datetime_slugs"`
+		DatetimeSlugTimezone string `ini:"datetime_slug_timezone"`
+		datetimeSlugLocation *time.Location
+
 		// Users
 		SingleUser       bool `ini:"single_user"`
 		OpenRegistration bool `ini:"open_registration"`
@@ -208,14 +213,15 @@ func New() *Config {
 			Bind: "localhost", /* IPV6 support when not using localhost? */
 		},
 		App: AppCfg{
-			Host:           "http://localhost:8080",
-			Theme:          "write",
-			WebFonts:       true,
-			SingleUser:     true,
-			MinUsernameLen: 3,
-			MaxBlogs:       1,
-			Federation:     true,
-			PublicStats:    true,
+			DatetimeSlugTimezone: "UTC",
+			Host:                 "http://localhost:8080",
+			Theme:                "write",
+			WebFonts:             true,
+			SingleUser:           true,
+			MinUsernameLen:       3,
+			MaxBlogs:             1,
+			Federation:           true,
+			PublicStats:          true,
 		},
 	}
 	c.UseMySQL(true)
@@ -281,6 +287,9 @@ func Load(fname string) (*Config, error) {
 	uc := &Config{}
 	err = cfg.MapTo(uc)
 	if err != nil {
+		return nil, err
+	}
+	if err := uc.App.initDatetimeSlugs(); err != nil {
 		return nil, err
 	}
 

--- a/config/datetime_slugs.go
+++ b/config/datetime_slugs.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+	_ "time/tzdata" // Keep IANA zones available in standalone binaries and minimal images.
+)
+
+func (ac *AppCfg) initDatetimeSlugs() error {
+	ac.DatetimeSlugTimezone = strings.TrimSpace(ac.DatetimeSlugTimezone)
+	if ac.DatetimeSlugTimezone == "" {
+		ac.DatetimeSlugTimezone = "UTC"
+	}
+	if !ac.DatetimeSlugs {
+		return nil
+	}
+	loc, err := ac.slugLocation()
+	if err != nil {
+		return err
+	}
+	ac.datetimeSlugLocation = loc
+	return nil
+}
+
+func (ac *AppCfg) slugLocation() (*time.Location, error) {
+	name := strings.TrimSpace(ac.DatetimeSlugTimezone)
+	if name == "" {
+		name = "UTC"
+	}
+	if name == "Local" {
+		return nil, fmt.Errorf("app.datetime_slug_timezone must be UTC or an IANA timezone, not Local")
+	}
+	if ac.datetimeSlugLocation != nil && ac.datetimeSlugLocation.String() == name {
+		return ac.datetimeSlugLocation, nil
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		return nil, fmt.Errorf("invalid app.datetime_slug_timezone %q: %w", name, err)
+	}
+	return loc, nil
+}
+
+// DatetimeSlug formats the publication instant without changing it. An empty
+// result means the caller should use the original automatic slug generation.
+func (ac *AppCfg) DatetimeSlug(created time.Time) (string, error) {
+	if !ac.DatetimeSlugs {
+		return "", nil
+	}
+	loc, err := ac.slugLocation()
+	if err != nil {
+		return "", err
+	}
+	return created.In(loc).Format("20060102150405"), nil
+}

--- a/config/datetime_slugs_test.go
+++ b/config/datetime_slugs_test.go
@@ -1,0 +1,84 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDatetimeSlugConfiguration(t *testing.T) {
+	if c := New(); c.App.DatetimeSlugs || c.App.DatetimeSlugTimezone != "UTC" {
+		t.Fatal("incorrect defaults")
+	}
+	for _, tc := range []struct {
+		name, settings, zone string
+		enabled, invalid     bool
+	}{
+		{"missing", "", "UTC", false, false},
+		{"empty", "datetime_slugs = true\ndatetime_slug_timezone =", "UTC", true, false},
+		{"Tokyo", "datetime_slugs = true\ndatetime_slug_timezone = Asia/Tokyo", "Asia/Tokyo", true, false},
+		{"invalid enabled", "datetime_slugs = true\ndatetime_slug_timezone = Invalid/Zone", "", true, true},
+		{"local rejected", "datetime_slugs = true\ndatetime_slug_timezone = Local", "", true, true},
+		{"invalid disabled", "datetime_slugs = false\ndatetime_slug_timezone = Invalid/Zone", "Invalid/Zone", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.ini")
+			if err := os.WriteFile(path, []byte("[app]\nhost = https://example.com\n"+tc.settings+"\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cfg, err := Load(path)
+			if tc.invalid {
+				if err == nil || !strings.Contains(err.Error(), "datetime_slug_timezone") {
+					t.Fatalf("expected timezone error, got %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.App.DatetimeSlugs != tc.enabled || cfg.App.DatetimeSlugTimezone != tc.zone {
+				t.Fatalf("unexpected config: %+v", cfg.App)
+			}
+			if err := Save(cfg, path); err != nil {
+				t.Fatal(err)
+			}
+			roundtrip, err := Load(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if roundtrip.App.DatetimeSlugs != tc.enabled || roundtrip.App.DatetimeSlugTimezone != tc.zone {
+				t.Fatal("settings lost on round trip")
+			}
+		})
+	}
+}
+
+func TestDatetimeSlugTimezone(t *testing.T) {
+	for _, tc := range []struct{ zone, created, want string }{
+		{"", "2026-09-05T15:30:00Z", "20260905153000"},
+		{"UTC", "2026-09-06T00:30:00+09:00", "20260905153000"},
+		{"Asia/Tokyo", "2026-09-05T15:30:00Z", "20260906003000"},
+		{"America/New_York", "2026-07-01T12:00:00Z", "20260701080000"},
+		{"America/New_York", "2026-01-01T12:00:00Z", "20260101070000"},
+	} {
+		t.Run(tc.zone+tc.created, func(t *testing.T) {
+			created, err := time.Parse(time.RFC3339, tc.created)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cfg := AppCfg{DatetimeSlugs: true, DatetimeSlugTimezone: tc.zone}
+			for _, offset := range []int{-7 * 3600, 9 * 3600} {
+				got, err := cfg.DatetimeSlug(created.In(time.FixedZone("source", offset)))
+				if err != nil || got != tc.want {
+					t.Fatalf("got %q, %v; want %q", got, err, tc.want)
+				}
+			}
+		})
+	}
+	cfg := AppCfg{DatetimeSlugTimezone: "Invalid/Zone"}
+	if got, err := cfg.DatetimeSlug(time.Now()); got != "" || err != nil {
+		t.Fatalf("disabled feature: %q %v", got, err)
+	}
+}

--- a/database.go
+++ b/database.go
@@ -1796,6 +1796,11 @@ func (db *datastore) ClaimPosts(cfg *config.Config, userID int64, collAlias stri
 					continue
 				}
 			}
+			// blue note.: use publication timestamp as the post slug.
+			if coll.Alias == "blue0a6m5c" {
+				p.Slug = time.Now().Format("20060102150405")
+			}
+
 			if p.Slug == "" {
 				p.Slug = p.ID
 			}

--- a/database.go
+++ b/database.go
@@ -86,8 +86,8 @@ type writestore interface {
 	GetAnonymousPosts(u *User, page int) (*[]PublicPost, error)
 	GetUserPosts(u *User) (*[]PublicPost, error)
 
-	CreateOwnedPost(post *SubmittedPost, accessToken, collAlias, hostName string) (*PublicPost, error)
-	CreatePost(userID, collID int64, post *SubmittedPost) (*Post, error)
+	CreateOwnedPost(cfg *config.Config, post *SubmittedPost, accessToken, collAlias, hostName string) (*PublicPost, error)
+	CreatePost(cfg *config.Config, userID, collID int64, post *SubmittedPost) (*Post, error)
 	UpdateOwnedPost(post *AuthenticatedPost, userID int64) error
 	GetEditablePost(id, editToken string) (*PublicPost, error)
 	PostIDExists(id string) bool
@@ -639,7 +639,7 @@ func (db *datastore) ConsumePasswordResetToken(t string) error {
 	return nil
 }
 
-func (db *datastore) CreateOwnedPost(post *SubmittedPost, accessToken, collAlias, hostName string) (*PublicPost, error) {
+func (db *datastore) CreateOwnedPost(cfg *config.Config, post *SubmittedPost, accessToken, collAlias, hostName string) (*PublicPost, error) {
 	var userID, collID int64 = -1, -1
 	var coll *Collection
 	var err error
@@ -662,7 +662,7 @@ func (db *datastore) CreateOwnedPost(post *SubmittedPost, accessToken, collAlias
 	}
 
 	rp := &PublicPost{}
-	rp.Post, err = db.CreatePost(userID, collID, post)
+	rp.Post, err = db.CreatePost(cfg, userID, collID, post)
 	if err != nil {
 		return rp, err
 	}
@@ -673,7 +673,7 @@ func (db *datastore) CreateOwnedPost(post *SubmittedPost, accessToken, collAlias
 	return rp, nil
 }
 
-func (db *datastore) CreatePost(userID, collID int64, post *SubmittedPost) (*Post, error) {
+func (db *datastore) CreatePost(cfg *config.Config, userID, collID int64, post *SubmittedPost) (*Post, error) {
 	idLen := postIDLen
 	friendlyID := id.GenerateFriendlyRandomString(idLen)
 
@@ -733,6 +733,16 @@ func (db *datastore) CreatePost(userID, collID int64, post *SubmittedPost) (*Pos
 				// SQLite stores datetimes in UTC, so convert time.Now() to it here
 				created = created.UTC()
 			}
+		}
+	}
+
+	if ownerCollID.Valid && (post.Slug == nil || *post.Slug == "") {
+		datetimeSlug, err := cfg.App.DatetimeSlug(created)
+		if err != nil {
+			return nil, err
+		}
+		if datetimeSlug != "" {
+			slug = sql.NullString{String: datetimeSlug, Valid: true}
 		}
 	}
 
@@ -1796,9 +1806,36 @@ func (db *datastore) ClaimPosts(cfg *config.Config, userID int64, collAlias stri
 					continue
 				}
 			}
-			// blue note.: use publication timestamp as the post slug.
-			if coll.Alias == "blue0a6m5c" {
-				p.Slug = time.Now().Format("20060102150405")
+			// Read the saved slug and publication instant under the same ownership
+			// conditions as the update. Re-collecting must not regenerate URLs,
+			// even after the feature is disabled or the publication date changes.
+			var savedSlug sql.NullString
+			var created time.Time
+			if canCollect {
+				err = db.QueryRow("SELECT slug, created FROM posts WHERE id = ? AND owner_id = ?", p.ID, userID).Scan(&savedSlug, &created)
+			} else {
+				err = db.QueryRow("SELECT slug, created FROM posts WHERE id = ? AND modify_token = ? AND owner_id IS NULL", p.ID, p.Token).Scan(&savedSlug, &created)
+			}
+			if err != nil {
+				r.ID, r.Code, r.ErrorMessage = p.ID, http.StatusInternalServerError, "Unable to read post metadata."
+				if err == sql.ErrNoRows {
+					r.Code, r.ErrorMessage = http.StatusForbidden, "Post not found or not owned."
+				}
+				res = append(res, r)
+				continue
+			}
+			if savedSlug.String != "" {
+				p.Slug = savedSlug.String
+			} else {
+				datetimeSlug, err := cfg.App.DatetimeSlug(created)
+				if err != nil {
+					r.ID, r.Code, r.ErrorMessage = p.ID, http.StatusInternalServerError, err.Error()
+					res = append(res, r)
+					continue
+				}
+				if datetimeSlug != "" {
+					p.Slug = datetimeSlug
+				}
 			}
 
 			if p.Slug == "" {
@@ -1814,6 +1851,10 @@ func (db *datastore) ClaimPosts(cfg *config.Config, userID int64, collAlias stri
 				query = "UPDATE posts SET owner_id = ?, collection_id = ?, slug = ? WHERE id = ? AND modify_token = ? AND owner_id IS NULL"
 				params = []interface{}{userID, coll.ID, p.Slug, p.ID, p.Token}
 				slugIdx = 2
+			}
+			if savedSlug.String != "" {
+				// A destination collision must fail rather than rename a saved slug.
+				slugIdx = -1
 			}
 		} else {
 			query = "UPDATE posts SET owner_id = ? WHERE id = ? AND modify_token = ? AND owner_id IS NULL"

--- a/datetime_slugs_test.go
+++ b/datetime_slugs_test.go
@@ -1,0 +1,251 @@
+package writefreely
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/writefreely/writefreely/config"
+)
+
+func slugTestPost(t *testing.T, app *App, userID, collID int64, created, explicit string) *Post {
+	t.Helper()
+	title, content := "Draft Title", "Draft body"
+	submitted := &SubmittedPost{Title: &title, Content: &content, Created: &created}
+	if explicit != "" {
+		submitted.Slug = &explicit
+	}
+	post, err := app.db.CreatePost(app.cfg, userID, collID, submitted)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if _, err := app.db.Exec("DELETE FROM posts WHERE id = ?", post.ID); err != nil {
+			t.Error(err)
+		}
+	})
+	return post
+}
+
+func slugTestClaim(t *testing.T, app *App, userID int64, alias, id string, viaClaim bool) string {
+	t.Helper()
+	requests := []ClaimPostRequest{{AnonymousAuthPost: &AnonymousAuthPost{ID: id}}}
+	target := alias
+	if viaClaim {
+		target = ""
+		requests[0].CollectionAlias = alias
+	}
+	results, err := app.db.ClaimPosts(app.cfg, userID, target, &requests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results == nil || len(*results) != 1 || (*results)[0].Code != http.StatusOK || (*results)[0].Post == nil {
+		t.Fatalf("claim failed: %+v", results)
+	}
+	post := (*results)[0].Post
+	var saved string
+	var collection int64
+	if err := app.db.QueryRow("SELECT slug, collection_id FROM posts WHERE id = ?", id).Scan(&saved, &collection); err != nil {
+		t.Fatal(err)
+	}
+	if saved != post.Slug.String || collection != post.Collection.ID {
+		t.Fatal("claim response differs from persisted metadata")
+	}
+	return saved
+}
+
+func TestBlueNoteConfiguredDatetimeSlugs(t *testing.T) {
+	app, _ := newTemplateTestApp(t, func(c *config.Config) { c.App.SingleUser = false })
+	for _, alias := range []string{"blue0a6m5c", "otherblog"} {
+		user, coll, _ := createTemplateTestUser(t, app, alias)
+		for _, enabled := range []bool{false, true} {
+			for _, route := range []string{"direct", "collect", "claim"} {
+				for _, created := range []string{"2001-02-03T15:05:06Z", "2099-02-03T15:05:06Z"} {
+					t.Run(fmt.Sprintf("%s/on=%t/%s/%s", alias, enabled, route, created), func(t *testing.T) {
+						app.cfg.App.DatetimeSlugs, app.cfg.App.DatetimeSlugTimezone = enabled, "Asia/Tokyo"
+						collID := int64(0)
+						if route == "direct" {
+							collID = coll.ID
+						}
+						post := slugTestPost(t, app, user.ID, collID, created, "")
+						got := post.Slug.String
+						if route != "direct" {
+							if got != "" {
+								t.Fatal("draft must not generate a slug")
+							}
+							got = slugTestClaim(t, app, user.ID, alias, post.ID, route == "claim")
+						}
+						want := "draft-title"
+						if enabled {
+							want = created[:4] + "0204000506"
+						}
+						if got != want {
+							t.Fatalf("slug = %q, want %q", got, want)
+						}
+					})
+				}
+			}
+		}
+		app.cfg.App.DatetimeSlugs = false
+	}
+}
+
+func TestBlueNoteSavedSlugStability(t *testing.T) {
+	app, _ := newTemplateTestApp(t, func(c *config.Config) { c.App.SingleUser = false })
+	user, coll, _ := createTemplateTestUser(t, app, "stable")
+	for _, explicit := range []string{"", "my-permanent-url"} {
+		t.Run("explicit="+explicit, func(t *testing.T) {
+			app.cfg.App.DatetimeSlugs, app.cfg.App.DatetimeSlugTimezone = true, "Asia/Tokyo"
+			post := slugTestPost(t, app, user.ID, coll.ID, "2001-02-03T15:05:06Z", explicit)
+			want := "20010204000506"
+			if explicit != "" {
+				want = explicit
+			}
+			if post.Slug.String != want {
+				t.Fatalf("initial slug = %q, want %q", post.Slug.String, want)
+			}
+			for _, enabled := range []bool{true, false, true} {
+				app.cfg.App.DatetimeSlugs, app.cfg.App.DatetimeSlugTimezone = enabled, "UTC"
+				created := "2099-01-01T00:00:00Z"
+				if err := app.db.UpdateOwnedPost(&AuthenticatedPost{ID: post.ID, SubmittedPost: &SubmittedPost{Created: &created}}, user.ID); err != nil {
+					t.Fatal(err)
+				}
+				var saved string
+				if err := app.db.QueryRow("SELECT slug FROM posts WHERE id = ?", post.ID).Scan(&saved); err != nil {
+					t.Fatal(err)
+				}
+				if saved != want {
+					t.Fatal("date edit changed slug")
+				}
+				if got := slugTestClaim(t, app, user.ID, coll.Alias, post.ID, false); got != want {
+					t.Fatal("repeated collect changed slug")
+				}
+				ids := []string{post.ID}
+				results, err := app.db.DispersePosts(user.ID, ids)
+				if err != nil || (*results)[0].Code != http.StatusOK {
+					t.Fatalf("disperse failed: %v", err)
+				}
+				if got := slugTestClaim(t, app, user.ID, coll.Alias, post.ID, true); got != want {
+					t.Fatal("reclaim changed saved slug")
+				}
+			}
+		})
+	}
+}
+
+func TestBlueNoteDatetimeSlugCollisions(t *testing.T) {
+	app, _ := newTemplateTestApp(t, func(c *config.Config) { c.App.SingleUser = false })
+	user, coll, _ := createTemplateTestUser(t, app, "collisions")
+	app.cfg.App.DatetimeSlugs = true
+	created, base := "2001-02-03T04:05:06Z", "20010203040506"
+	first := slugTestPost(t, app, user.ID, coll.ID, created, "")
+	second := slugTestPost(t, app, user.ID, coll.ID, created, "")
+	if first.Slug.String != base || second.Slug.String == base || !strings.HasPrefix(second.Slug.String, base) {
+		t.Fatal("direct creation did not resolve timestamp collision")
+	}
+	draft := slugTestPost(t, app, user.ID, 0, created, "")
+	got := slugTestClaim(t, app, user.ID, coll.Alias, draft.ID, false)
+	if got == base || got == second.Slug.String || !strings.HasPrefix(got, base) {
+		t.Fatal("claim did not resolve timestamp collision")
+	}
+	other, err := app.db.CreateCollection(app.cfg, "destination", "", user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	slugTestPost(t, app, user.ID, other.ID, created, base)
+	requests := []ClaimPostRequest{{AnonymousAuthPost: &AnonymousAuthPost{ID: first.ID}}}
+	results, err := app.db.ClaimPosts(app.cfg, user.ID, other.Alias, &requests)
+	if err != nil || (*results)[0].Code == http.StatusOK {
+		t.Fatalf("saved slug collision should reject move: %v", err)
+	}
+	var saved string
+	var collID int64
+	if err := app.db.QueryRow("SELECT slug, collection_id FROM posts WHERE id = ?", first.ID).Scan(&saved, &collID); err != nil {
+		t.Fatal(err)
+	}
+	if saved != base || collID != coll.ID {
+		t.Fatal("failed move modified persisted URL")
+	}
+
+}
+
+func TestBlueNoteSlugDefaultsAndExplicitValues(t *testing.T) {
+	app, _ := newTemplateTestApp(t, func(c *config.Config) { c.App.SingleUser = false })
+	user, coll, _ := createTemplateTestUser(t, app, "defaults")
+	for _, tc := range []struct{ name, title, body, explicit, want string }{
+		{"title", "Some Title", "Some body", "", "some-title"},
+		{"body", "", "Some body", "", "some-body"},
+		{"id fallback", "", "!!!", "", ""},
+		{"explicit", "Title", "Body", "chosen-url", "chosen-url"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			app.cfg.App.DatetimeSlugs = false
+			post, err := app.db.CreatePost(app.cfg, user.ID, coll.ID, &SubmittedPost{Title: &tc.title, Content: &tc.body, Slug: &tc.explicit})
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := tc.want
+			if want == "" {
+				want = post.ID
+			}
+			if post.Slug.String != want {
+				t.Fatalf("slug = %q, want %q", post.Slug.String, want)
+			}
+		})
+	}
+	app.cfg.App.DatetimeSlugs, app.cfg.App.DatetimeSlugTimezone = true, "UTC"
+	title, content := "Current", "Body"
+	post, err := app.db.CreatePost(app.cfg, user.ID, coll.ID, &SubmittedPost{Title: &title, Content: &content})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if post.Slug.String != post.Created.UTC().Format("20060102150405") {
+		t.Fatal("slug does not match the resolved default Created")
+	}
+
+	// Exercise the access-token creation path too.
+	token, err := app.db.GetAccessToken(user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created := "2002-03-04T05:06:07Z"
+	owned, err := app.db.CreateOwnedPost(app.cfg, &SubmittedPost{Title: &title, Content: &content, Created: &created}, "Token "+token, coll.Alias, app.cfg.App.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if owned.Slug.String != "20020304050607" {
+		t.Fatalf("token creation slug = %q", owned.Slug.String)
+	}
+}
+
+func TestBlueNoteAnonymousClaimDatetimeSlug(t *testing.T) {
+	app, _ := newTemplateTestApp(t, func(c *config.Config) { c.App.SingleUser = false })
+	user, coll, _ := createTemplateTestUser(t, app, "anonymous-claim")
+	app.cfg.App.DatetimeSlugs, app.cfg.App.DatetimeSlugTimezone = true, "Asia/Tokyo"
+	post := slugTestPost(t, app, 0, 0, "2001-02-03T15:05:06Z", "")
+	if _, err := app.db.Exec("UPDATE posts SET modify_token = ? WHERE id = ?", "edit-token", post.ID); err != nil {
+		t.Fatal(err)
+	}
+	for _, token := range []string{"wrong-token", "edit-token"} {
+		requests := []ClaimPostRequest{{AnonymousAuthPost: &AnonymousAuthPost{ID: post.ID, Token: token}}}
+		results, err := app.db.ClaimPosts(app.cfg, user.ID, coll.Alias, &requests)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := (*results)[0]
+		if token == "wrong-token" {
+			if result.Code != http.StatusForbidden {
+				t.Fatalf("invalid token accepted: %+v", result)
+			}
+			continue
+		}
+		if result.Code != http.StatusOK || result.Post.Slug.String != "20010204000506" {
+			t.Fatalf("anonymous claim: %+v", result)
+		}
+		if !result.Post.Created.Equal(time.Date(2001, 2, 3, 15, 5, 6, 0, time.UTC)) {
+			t.Fatal("claim changed publication time")
+		}
+	}
+}

--- a/docs/datetime-slugs.md
+++ b/docs/datetime-slugs.md
@@ -1,0 +1,46 @@
+# Datetime slugs
+
+BlueNote can generate post slugs from the saved publication time. Defaults:
+
+```ini
+[app]
+datetime_slugs = false
+datetime_slug_timezone = UTC
+```
+
+To generate dates in Japan time, set `datetime_slugs = true` and
+`datetime_slug_timezone = Asia/Tokyo`. Any loadable IANA timezone is supported;
+`Local` is rejected. An absent or empty timezone means UTC. An invalid timezone
+prevents configuration loading when the feature is enabled; it is ignored when
+disabled. Restart the server after changing the configuration.
+
+Automatic slugs use the finalized `Created` instant converted to the configured
+timezone, formatted as `YYYYMMDDHHMMSS`. Direct posts, API posts, imports and
+drafts collected into a blog use the same setting. Drafts without a blog do not
+receive an automatic slug until collected. Collection does not reset `Created`:
+an old draft keeps its old publication time, and a scheduled post uses its
+scheduled time. Explicit slugs on creation take precedence.
+
+Saved slugs are retained on collection/recollection, even after editing the
+publication date, changing timezone, or disabling the feature. Explicit slug
+edits remain possible. A new automatic slug collision uses the existing unique
+suffix mechanism, so the final slug may exceed 14 characters. Moving a saved
+slug into a blog where it collides fails instead of automatically renaming it.
+Moving between blogs still changes the blog portion of the URL.
+
+When disabled, new automatic slugs use WriteFreely's title/body/ID rules.
+Preserving already-saved slugs on recollection is intentional even when disabled.
+Database timestamps, scheduling, and ActivityPub timestamps are not converted
+or rewritten by this setting. Go's standard `time/tzdata` provides timezone data
+when system timezone files are unavailable.
+
+Regression tests (SQLite requires CGO and a C compiler):
+
+```sh
+go test -mod=readonly ./config
+go test -mod=readonly -vet=off -tags sqlite -run TestBlueNote -count=1 .
+```
+
+`-vet=off` bypasses pre-existing format-string vet failures in the root package;
+it does not suppress failing test assertions. Known upstream test failures are
+not fixed by this change.

--- a/posts.go
+++ b/posts.go
@@ -660,7 +660,7 @@ func newPost(app *App, w http.ResponseWriter, r *http.Request) error {
 	var newPost *PublicPost = &PublicPost{}
 	var coll *Collection
 	if accessToken != "" {
-		newPost, err = app.db.CreateOwnedPost(p, accessToken, collAlias, app.cfg.App.Host)
+		newPost, err = app.db.CreateOwnedPost(app.cfg, p, accessToken, collAlias, app.cfg.App.Host)
 	} else {
 		//return ErrNotLoggedIn
 		// TODO: verify user is logged in
@@ -677,7 +677,7 @@ func newPost(app *App, w http.ResponseWriter, r *http.Request) error {
 			collID = coll.ID
 		}
 		// TODO: return PublicPost from createPost
-		newPost.Post, err = app.db.CreatePost(userID, collID, p)
+		newPost.Post, err = app.db.CreatePost(app.cfg, userID, collID, p)
 	}
 	if err != nil {
 		return err

--- a/posts.go
+++ b/posts.go
@@ -280,7 +280,7 @@ func (p *Post) CreatedDate() string {
 }
 
 func (p *Post) Created8601() string {
-	return p.Created.Format("2006-01-02T15:04:05Z")
+	return p.Created.UTC().Format("2006-01-02T15:04:05Z")
 }
 
 func (p *Post) IsScheduled() bool {
@@ -1741,14 +1741,14 @@ func (rp *RawPost) UserFacingCreated() string {
 }
 
 func (rp *RawPost) Created8601() string {
-	return rp.Created.Format("2006-01-02T15:04:05Z")
+	return rp.Created.UTC().Format("2006-01-02T15:04:05Z")
 }
 
 func (rp *RawPost) Updated8601() string {
 	if rp.Updated.IsZero() {
 		return ""
 	}
-	return rp.Updated.Format("2006-01-02T15:04:05Z")
+	return rp.Updated.UTC().Format("2006-01-02T15:04:05Z")
 }
 
 var imageURLRegex = regexp.MustCompile(`(?i)[^ ]+\.(gif|png|jpg|jpeg|avif|avifs|webp|jxl|image)$`)

--- a/posts.go
+++ b/posts.go
@@ -1314,7 +1314,8 @@ func (p *PublicPost) ActivityObject(app *App) *activitystreams.Object {
 	// Add shortened Note as the `preview` property if this is an Article
 	if o.Type == "Article" {
 		o.Preview = p.PreviewObject(app, o)
-		o.Summary = &o.Preview.Content
+		summary := stripHTMLWithoutEscaping(o.Preview.Content)
+		o.Summary = &summary
 	}
 
 	return o

--- a/template_render_test.go
+++ b/template_render_test.go
@@ -211,7 +211,7 @@ func createTemplateTestUser(t *testing.T, app *App, username string) (*User, *Co
 
 	title := "Hello World"
 	content := "This is a **test** post used to exercise template rendering.\n\nIt has multiple paragraphs, and a [link](https://example.com)."
-	post, err := app.db.CreatePost(u.ID, coll.ID, &SubmittedPost{Title: &title, Content: &content})
+	post, err := app.db.CreatePost(app.cfg, u.ID, coll.ID, &SubmittedPost{Title: &title, Content: &content})
 	if err != nil {
 		t.Fatalf("create post: %v", err)
 	}


### PR DESCRIPTION
## Summary

Adds configurable datetime-based post slugs to BlueNote.

- Adds `datetime_slugs` under `[app]`
- Adds configurable IANA timezone support via `datetime_slug_timezone`
- Uses the post's `Created` timestamp when generating datetime slugs
- Preserves explicitly specified and previously saved slugs
- Supports both direct post creation and claiming posts into a collection
- Removes the previous BlueNote-specific alias hardcoding
- Embeds Go timezone data for environment-independent timezone handling
- Keeps the upstream WriteFreely slug behavior when disabled

Example:

```ini
[app]
datetime_slugs = true
datetime_slug_timezone = Asia/Tokyo

This generates slugs such as:

20260905153000

Compatibility

The feature is disabled by default, preserving upstream WriteFreely behavior.

Changing the publication date, timezone configuration, or feature setting does not automatically change an existing saved slug.

Testing

Added coverage for:

default/off behavior
UTC and IANA timezone handling
Asia/Tokyo date boundaries
direct post creation and claiming
past and scheduled publication dates
explicit and existing slug preservation
collision handling
timezone-independent behavior
existing BlueNote regressions
